### PR TITLE
사이즈 입력 폼 리팩토링 및 컴포넌트화 완료

### DIFF
--- a/components/common/SizeForm/Alert.tsx
+++ b/components/common/SizeForm/Alert.tsx
@@ -4,12 +4,11 @@ import theme from 'styles/theme';
 
 interface AlertProps {
   message: string;
-  isActive: boolean;
   setIsActive: (prev: boolean) => void;
 }
 
 function Alert(props: AlertProps) {
-  const { message, isActive, setIsActive } = props;
+  const { message, setIsActive } = props;
 
   const disableClick = () => {
     //(document.activeElement as HTMLElement).blur();
@@ -24,7 +23,7 @@ function Alert(props: AlertProps) {
   }, []);
 
   return (
-    <Styled.Root isAlert={isActive}>
+    <Styled.Root>
       {message}
       <br />
       다시 입력해 주세요.
@@ -37,7 +36,7 @@ export default Alert;
 
 const Styled = {
   Root: styled.div<{ isAlert?: boolean }>`
-    display: ${({ isAlert }) => (isAlert ? 'flex' : 'none')};
+    display: flex;
     position: fixed;
     top: 0;
     left: 50%;

--- a/components/common/SizeForm/RadioButton.tsx
+++ b/components/common/SizeForm/RadioButton.tsx
@@ -13,12 +13,7 @@ function RadioButton(props: RadioProps) {
   const { isClicked, label, onClick } = props;
 
   return (
-    <Styled.Radio
-      //   onClick={() => {
-      //     setMeasure(text);
-      //   }}
-      onClick={onClick}
-    >
+    <Styled.Radio onClick={onClick}>
       <Image src={isClicked ? RadioClickedIcon : RadioIcon} alt="라디오버튼 아이콘" width={22} height={22} />
       <label>{label}</label>
     </Styled.Radio>

--- a/components/common/SizeForm/RadioButton.tsx
+++ b/components/common/SizeForm/RadioButton.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { RadioClickedIcon, RadioIcon } from 'assets/icon';
+import Image from 'next/image';
+import styled from 'styled-components';
+
+interface RadioProps {
+  isClicked: boolean;
+  label: string;
+  onClick: () => void;
+}
+
+function RadioButton(props: RadioProps) {
+  const { isClicked, label, onClick } = props;
+
+  return (
+    <Styled.Radio
+      //   onClick={() => {
+      //     setMeasure(text);
+      //   }}
+      onClick={onClick}
+    >
+      <Image src={isClicked ? RadioClickedIcon : RadioIcon} alt="라디오버튼 아이콘" width={22} height={22} />
+      <label>{label}</label>
+    </Styled.Radio>
+  );
+}
+
+export default RadioButton;
+
+const Styled = {
+  Radio: styled.span`
+    display: flex;
+    align-items: center;
+    margin-right: 3rem;
+    cursor: pointer;
+    > label {
+      margin-left: 0.8rem;
+    }
+  `,
+};

--- a/components/common/SizeForm/SizeForm.tsx
+++ b/components/common/SizeForm/SizeForm.tsx
@@ -26,12 +26,6 @@ interface FormProps {
   setProgress: (prev: number) => void;
 }
 
-const formTypeMapper = {
-  '상/하의': '상의',
-  상의: '상의',
-  하의: '하의',
-};
-
 // 상의 총장, 어깨너비
 const topScopeMapper = {
   총장: { min: 30, max: 180 },
@@ -165,7 +159,7 @@ export default function SizeForm(props: FormProps) {
   };
 
   useEffect(() => {
-    // input이 하나라도 비어있지 않은 경우 다음 버튼 활성화
+    // input이 다 채워졌으면 다음 버튼 활성화
     watch((formObject) => {
       if (!Object.values(formObject).includes('')) {
         setIsNextActive(true);
@@ -179,72 +173,30 @@ export default function SizeForm(props: FormProps) {
 
   return (
     <Styled.Root>
-      {!noHeader && formType && <Styled.Header>{formTypeMapper[formType]} 사이즈를 입력해주세요</Styled.Header>}
+      {!noHeader && formType && <Styled.Header>{formType} 사이즈를 입력해주세요</Styled.Header>}
       {formType === '하의' ? (
+        // 하의 사이즈 입력 폼
         <Styled.Form onSubmit={handleSubmit(onValidBottom)}>
           {Object.entries(bottomScopeMappper).map(([key, { min, max }]) => (
-            <Styled.InputContainer key={key}>
-              <label>{key}</label>
-              <div>
-                <Styled.Input
-                  type="number"
-                  step="0.1"
-                  {...register(key, {
-                    required: true,
-                    validate: (value) =>
-                      value < min || value > max
-                        ? `${key}은 최소 ${min}부터 최대 ${max}까지 입력할 수 있습니다.`
-                        : true,
-                  })}
-                  onBlur={(e) => e.currentTarget.value && setValue(key, parseFloat(e.currentTarget.value).toFixed(1))}
-                />
-                cm
-              </div>
-            </Styled.InputContainer>
+            <SizeInput key={key} inputKey={key} register={register} setValue={setValue} valid={{ min, max }} />
           ))}
           <Styled.RadioContainer>
-            {measureList.map((text, index) => (
-              <Styled.Radio
-                key={index}
-                onClick={() => {
-                  setMeasure(text);
-                }}
-              >
-                <Image
-                  src={text === measure ? RadioClickedIcon : RadioIcon}
-                  alt="라디오버튼 아이콘"
-                  width={22}
-                  height={22}
-                />
-                <label>{text}</label>
-              </Styled.Radio>
-            ))}
+            <RadioButton onClick={() => setMeasure('단면')} label="단면" isClicked={measure === '단면'} />
+            <RadioButton onClick={() => setMeasure('둘레')} label="둘레" isClicked={measure === '둘레'} />
           </Styled.RadioContainer>
           {Object.entries(bottomSwitchMapper).map(([key, scope]) => (
-            <Styled.InputContainer key={key}>
-              <label>
-                {key} {measure}
-              </label>
-              <div>
-                <Styled.Input
-                  type="number"
-                  step="0.1"
-                  {...register(key, {
-                    required: true,
-                    validate: (value) =>
-                      value < scope[measure].min || value > scope[measure].max
-                        ? `${key} ${measure}은 최소 ${scope[measure].min}부터 최대 ${scope[measure].max}까지 입력할 수 있습니다.`
-                        : true,
-                  })}
-                  onBlur={(e) => e.currentTarget.value && setValue(key, parseFloat(e.currentTarget.value).toFixed(1))}
-                />
-                cm
-              </div>
-            </Styled.InputContainer>
+            <SizeInput
+              key={key}
+              inputKey={key}
+              register={register}
+              setValue={setValue}
+              valid={{ min: scope[measure].min, max: scope[measure].max }}
+            />
           ))}
           <NextButton isActive={isNextActive} onClick={onClickNextButton} />
         </Styled.Form>
       ) : (
+        // 상의 사이즈 입력 폼
         <Styled.Form onSubmit={handleSubmit(onValidTop)}>
           {Object.entries(topScopeMapper).map(([key, { min, max }]) => (
             <SizeInput key={key} inputKey={key} register={register} setValue={setValue} valid={{ min, max }} />
@@ -254,7 +206,7 @@ export default function SizeForm(props: FormProps) {
             <RadioButton onClick={() => setMeasure('둘레')} label="둘레" isClicked={measure === '둘레'} />
           </Styled.RadioContainer>
           <SizeInput
-            inputKey={`가슴 ${measure}`}
+            inputKey={'가슴'}
             register={register}
             setValue={setValue}
             valid={{ min: chestScopeMapper[measure].min, max: chestScopeMapper[measure].max }}
@@ -292,36 +244,6 @@ const Styled = {
     display: flex;
     flex-direction: column;
   `,
-  InputContainer: styled.div`
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    margin-top: 2.6rem;
-    color: ${theme.colors.gray550};
-    ${theme.fonts.caption1};
-    &:nth-child(1),
-    &:nth-child(4) {
-      margin-top: 0;
-    }
-    div {
-      display: flex;
-      align-items: flex-end;
-    }
-  `,
-  Input: styled.input`
-    width: 28.5rem;
-    height: 5.4rem;
-    margin-right: 1rem;
-    padding-left: 1.6rem;
-    background: ${theme.colors.gray000};
-    border: 0;
-    border-radius: 0.5rem;
-    color: #000000;
-    ${theme.fonts.body1};
-    :focus {
-      outline: none;
-    }
-  `,
   RadioContainer: styled.div`
     display: flex;
     justify-content: center;
@@ -330,14 +252,5 @@ const Styled = {
     margin-bottom: 3.6rem;
     color: ${theme.colors.gray550};
     ${theme.fonts.caption1}
-  `,
-  Radio: styled.span`
-    display: flex;
-    align-items: center;
-    margin-right: 3rem;
-    cursor: pointer;
-    > label {
-      margin-left: 0.8rem;
-    }
   `,
 };

--- a/components/common/SizeForm/SizeForm.tsx
+++ b/components/common/SizeForm/SizeForm.tsx
@@ -14,6 +14,8 @@ import NextButton from 'components/register/NextButton';
 import ModalPortal from '../modal/ModalPortal';
 
 import Alert from './Alert';
+import RadioButton from './RadioButton';
+import SizeInput from './SizeInput';
 
 interface FormProps {
   noHeader?: boolean;
@@ -63,8 +65,6 @@ const bottomSwitchMapper = {
   },
 };
 
-type MeasureType = '단면' | '둘레';
-
 type TopFormType = {
   총장: string;
   '어깨 너비': string;
@@ -96,8 +96,7 @@ const mutateMapper = {
 
 export default function SizeForm(props: FormProps) {
   const { noHeader, formType, isNextActive, setIsNextActive, progress, setProgress } = props;
-  const measureList: MeasureType[] = ['단면', '둘레'];
-  const [measure, setMeasure] = useState<MeasureType>('단면');
+  const [measure, setMeasure] = useState<'단면' | '둘레'>('단면');
   const [isAlertActive, setIsAlertActive] = useState(false);
 
   const {
@@ -248,61 +247,18 @@ export default function SizeForm(props: FormProps) {
       ) : (
         <Styled.Form onSubmit={handleSubmit(onValidTop)}>
           {Object.entries(topScopeMapper).map(([key, { min, max }]) => (
-            <Styled.InputContainer key={key}>
-              <label>{key}</label>
-              <div>
-                <Styled.Input
-                  type="number"
-                  step="0.1"
-                  {...register(key, {
-                    required: true,
-                    validate: (value) =>
-                      value < min || value > max
-                        ? `${key}은 최소 ${min}부터 최대 ${max}까지 입력할 수 있습니다.`
-                        : true,
-                  })}
-                  onBlur={(e) => e.currentTarget.value && setValue(key, parseFloat(e.currentTarget.value).toFixed(1))}
-                />
-                cm
-              </div>
-            </Styled.InputContainer>
+            <SizeInput key={key} inputKey={key} register={register} setValue={setValue} valid={{ min, max }} />
           ))}
           <Styled.RadioContainer>
-            {measureList.map((text, index) => (
-              <Styled.Radio
-                key={index}
-                onClick={() => {
-                  setMeasure(text);
-                }}
-              >
-                <Image
-                  src={text === measure ? RadioClickedIcon : RadioIcon}
-                  alt="라디오버튼 아이콘"
-                  width={22}
-                  height={22}
-                />
-                <label>{text}</label>
-              </Styled.Radio>
-            ))}
+            <RadioButton onClick={() => setMeasure('단면')} label="단면" isClicked={measure === '단면'} />
+            <RadioButton onClick={() => setMeasure('둘레')} label="둘레" isClicked={measure === '둘레'} />
           </Styled.RadioContainer>
-          <Styled.InputContainer>
-            <label>가슴 {measure}</label>
-            <div>
-              <Styled.Input
-                type="number"
-                step="0.1"
-                {...register('가슴', {
-                  required: true,
-                  validate: (value) =>
-                    value < chestScopeMapper[measure].min || value > chestScopeMapper[measure].max
-                      ? `가슴 ${measure}은 최소 ${chestScopeMapper[measure].min}부터 최대 ${chestScopeMapper[measure].max}까지 입력할 수 있습니다.`
-                      : true,
-                })}
-                onBlur={(e) => e.currentTarget.value && setValue('가슴', parseFloat(e.currentTarget.value).toFixed(1))}
-              />
-              cm
-            </div>
-          </Styled.InputContainer>
+          <SizeInput
+            inputKey={`가슴 ${measure}`}
+            register={register}
+            setValue={setValue}
+            valid={{ min: chestScopeMapper[measure].min, max: chestScopeMapper[measure].max }}
+          />
           <NextButton isActive={isNextActive} onClick={onClickNextButton} />
         </Styled.Form>
       )}

--- a/components/common/SizeForm/SizeForm.tsx
+++ b/components/common/SizeForm/SizeForm.tsx
@@ -1,7 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { SubmitHandler, useForm } from 'react-hook-form';
-import { RadioClickedIcon, RadioIcon } from 'assets/icon';
-import Image from 'next/image';
+import { useForm } from 'react-hook-form';
 import { useRouter } from 'next/router';
 import { OptionType } from 'pages/register';
 import styled from 'styled-components';
@@ -108,53 +106,49 @@ export default function SizeForm(props: FormProps) {
   const { postMyTopSize } = usePostMyTopSize();
   const { postMyBottomSize } = usePostMyBottomSize();
 
-  const onValidTop = async (data: TopFormType) => {
+  const onValid = async (data: TopFormType | BottomFormType) => {
     setIsAlertActive(false);
 
-    // 모든 유효성이 true이면 recoil에 저장 또는 서버에 넘기기
-    const inputData: TopSizeInput = {
-      topLength: 0,
-      shoulder: 0,
-      chest: 0,
-    };
+    if (formType === '상의') {
+      const inputData: TopSizeInput = {
+        topLength: 0,
+        shoulder: 0,
+        chest: 0,
+      };
 
-    Object.entries(data).map(([key, value]) => {
-      inputData[mutateMapper.top[key]] = parseFloat(value);
-    });
-
-    if (progress === 2) {
-      await postMyTopSize(inputData, () => {
-        setProgress(progress + 1);
-        resetField('총장');
+      Object.entries(mutateMapper.top).map(([kor, eng]) => {
+        inputData[eng] = parseFloat(data[kor]);
       });
+
+      if (progress === 2) {
+        await postMyTopSize(inputData, () => {
+          setProgress(progress + 1);
+          resetField('총장');
+        });
+      } else {
+        await postMyTopSize(inputData, () => router.push('/home'));
+      }
     } else {
-      await postMyTopSize(inputData, () => router.push('/home'));
-    }
-  };
+      const inputData: BottomSizeInput = {
+        bottomLength: 0,
+        waist: 0,
+        thigh: 0,
+        rise: 0,
+        hem: 0,
+      };
 
-  const onValidBottom = async (data: BottomFormType) => {
-    setIsAlertActive(false);
-
-    // 모든 유효성이 true이면 recoil에 저장 또는 서버에 넘기기
-    const inputData: BottomSizeInput = {
-      bottomLength: 0,
-      waist: 0,
-      thigh: 0,
-      rise: 0,
-      hem: 0,
-    };
-
-    Object.entries(data).map(([key, value]) => {
-      inputData[mutateMapper.bottom[key]] = parseFloat(value);
-    });
-
-    if (progress === 2) {
-      await postMyBottomSize(inputData, () => {
-        setProgress(progress + 1);
-        resetField('총장');
+      Object.entries(mutateMapper.bottom).map(([kor, eng]) => {
+        inputData[eng] = parseFloat(data[kor]);
       });
-    } else {
-      await postMyBottomSize(inputData, () => router.push('/home'));
+
+      if (progress === 2) {
+        await postMyBottomSize(inputData, () => {
+          setProgress(progress + 1);
+          resetField('총장');
+        });
+      } else {
+        await postMyBottomSize(inputData, () => router.push('/home'));
+      }
     }
   };
 
@@ -176,7 +170,7 @@ export default function SizeForm(props: FormProps) {
       {!noHeader && formType && <Styled.Header>{formType} 사이즈를 입력해주세요</Styled.Header>}
       {formType === '하의' ? (
         // 하의 사이즈 입력 폼
-        <Styled.Form onSubmit={handleSubmit(onValidBottom)}>
+        <Styled.Form onSubmit={handleSubmit(onValid)}>
           {Object.entries(bottomScopeMappper).map(([key, { min, max }]) => (
             <SizeInput key={key} inputKey={key} register={register} setValue={setValue} valid={{ min, max }} />
           ))}
@@ -197,7 +191,7 @@ export default function SizeForm(props: FormProps) {
         </Styled.Form>
       ) : (
         // 상의 사이즈 입력 폼
-        <Styled.Form onSubmit={handleSubmit(onValidTop)}>
+        <Styled.Form onSubmit={handleSubmit(onValid)}>
           {Object.entries(topScopeMapper).map(([key, { min, max }]) => (
             <SizeInput key={key} inputKey={key} register={register} setValue={setValue} valid={{ min, max }} />
           ))}

--- a/components/common/SizeForm/SizeForm.tsx
+++ b/components/common/SizeForm/SizeForm.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { useForm } from 'react-hook-form';
+import { FieldValues, SubmitHandler, useForm } from 'react-hook-form';
 import { useRouter } from 'next/router';
 import { OptionType } from 'pages/register';
 import styled from 'styled-components';
@@ -98,7 +98,7 @@ export default function SizeForm(props: FormProps) {
     handleSubmit,
     formState: { errors },
     resetField,
-  } = useForm({
+  } = useForm<FieldValues>({
     shouldFocusError: false,
   });
   const router = useRouter();
@@ -106,7 +106,7 @@ export default function SizeForm(props: FormProps) {
   const { postMyTopSize } = usePostMyTopSize();
   const { postMyBottomSize } = usePostMyBottomSize();
 
-  const onValid = async (data: TopFormType | BottomFormType) => {
+  const onValid: SubmitHandler<FieldValues> = async (data: FieldValues) => {
     setIsAlertActive(false);
 
     if (formType === '상의') {

--- a/components/common/SizeForm/SizeForm.tsx
+++ b/components/common/SizeForm/SizeForm.tsx
@@ -111,11 +111,16 @@ export default function SizeForm(props: FormProps) {
         topLength: 0,
         shoulder: 0,
         chest: 0,
+        isWidthOfTop: true,
       };
 
       Object.entries(mutateMapper.top).map(([kor, eng]) => {
         inputData[eng] = parseFloat(data[kor]);
       });
+
+      if (measure === '둘레') {
+        inputData.isWidthOfTop = false;
+      }
 
       postMyTopSize(inputData, () => {
         resetField('총장');
@@ -128,11 +133,16 @@ export default function SizeForm(props: FormProps) {
         thigh: 0,
         rise: 0,
         hem: 0,
+        isWidthOfBottom: true,
       };
 
       Object.entries(mutateMapper.bottom).map(([kor, eng]) => {
         inputData[eng] = parseFloat(data[kor]);
       });
+
+      if (measure === '둘레') {
+        inputData.isWidthOfBottom = false;
+      }
 
       postMyBottomSize(inputData, () => {
         resetField('총장');

--- a/components/common/SizeForm/SizeInput.tsx
+++ b/components/common/SizeForm/SizeInput.tsx
@@ -26,7 +26,7 @@ function SizeInput(props: InputProps) {
             required: true,
             validate: (value) =>
               value < valid.min || value > valid.max
-                ? `${label}은 최소 ${valid.min}부터 최대 ${valid.max}까지 입력할 수 있습니다.`
+                ? `${label}은(는) 최소 ${valid.min}부터 최대 ${valid.max}까지 입력할 수 있습니다.`
                 : true,
           })}
           onBlur={(e) => e.currentTarget.value && setValue(inputKey, parseFloat(e.currentTarget.value).toFixed(1))}

--- a/components/common/SizeForm/SizeInput.tsx
+++ b/components/common/SizeForm/SizeInput.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import { FieldValues, UseFormRegister, UseFormSetValue } from 'react-hook-form';
+import styled from 'styled-components';
+import theme from 'styles/theme';
+
+interface InputProps {
+  inputKey: string;
+  measure?: string;
+  register: UseFormRegister<FieldValues>;
+  setValue: UseFormSetValue<FieldValues>;
+  valid: { min: number; max: number };
+}
+
+function SizeInput(props: InputProps) {
+  const { inputKey, measure, register, setValue, valid } = props;
+  return (
+    <Styled.InputContainer key={inputKey}>
+      <label>
+        {inputKey} {measure}
+      </label>
+      <div>
+        <Styled.Input
+          type="number"
+          step="0.1"
+          {...register(inputKey, {
+            required: true,
+            validate: (value) =>
+              value < valid.min || value > valid.max
+                ? `${inputKey} ${measure}은 최소 ${valid.min}부터 최대 ${valid.max}까지 입력할 수 있습니다.`
+                : true,
+          })}
+          onBlur={(e) => e.currentTarget.value && setValue(inputKey, parseFloat(e.currentTarget.value).toFixed(1))}
+        />
+        cm
+      </div>
+    </Styled.InputContainer>
+  );
+}
+
+export default SizeInput;
+
+const Styled = {
+  InputContainer: styled.div`
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-top: 2.6rem;
+    color: ${theme.colors.gray550};
+    ${theme.fonts.caption1};
+    &:nth-child(1),
+    &:nth-child(4) {
+      margin-top: 0;
+    }
+    div {
+      display: flex;
+      align-items: flex-end;
+    }
+  `,
+  Input: styled.input`
+    width: 28.5rem;
+    height: 5.4rem;
+    margin-right: 1rem;
+    padding-left: 1.6rem;
+    background: ${theme.colors.gray000};
+    border: 0;
+    border-radius: 0.5rem;
+    color: #000000;
+    ${theme.fonts.body1};
+    :focus {
+      outline: none;
+    }
+  `,
+};

--- a/components/common/SizeForm/SizeInput.tsx
+++ b/components/common/SizeForm/SizeInput.tsx
@@ -13,11 +13,11 @@ interface InputProps {
 
 function SizeInput(props: InputProps) {
   const { inputKey, measure, register, setValue, valid } = props;
+  const label = measure ? `${inputKey} ${measure}` : `${inputKey}`;
+
   return (
     <Styled.InputContainer key={inputKey}>
-      <label>
-        {inputKey} {measure}
-      </label>
+      <label>{label}</label>
       <div>
         <Styled.Input
           type="number"
@@ -26,7 +26,7 @@ function SizeInput(props: InputProps) {
             required: true,
             validate: (value) =>
               value < valid.min || value > valid.max
-                ? `${inputKey} ${measure}은 최소 ${valid.min}부터 최대 ${valid.max}까지 입력할 수 있습니다.`
+                ? `${label}은 최소 ${valid.min}부터 최대 ${valid.max}까지 입력할 수 있습니다.`
                 : true,
           })}
           onBlur={(e) => e.currentTarget.value && setValue(inputKey, parseFloat(e.currentTarget.value).toFixed(1))}

--- a/hooks/business/mySize.ts
+++ b/hooks/business/mySize.ts
@@ -6,9 +6,9 @@ export const usePostMyTopSize = () => {
   const postMyTopSizeMutate = usePostMyTopSizeMutation();
 
   const postMyTopSize = async (body: TopSizeInput, onSuccessPost: () => void) => {
-    const { message } = await postMyTopSizeMutate.mutateAsync(body, {
+    const { data } = await postMyTopSizeMutate.mutateAsync(body, {
       onSuccess() {
-        console.log(message);
+        console.log(data);
         onSuccessPost();
       },
     });
@@ -21,9 +21,9 @@ export const usePostMyBottomSize = () => {
   const postMyBottomSizeMutate = usePostMyBottomSizeMutation();
 
   const postMyBottomSize = async (body: BottomSizeInput, onSuccessPost: () => void) => {
-    const { message } = await postMyBottomSizeMutate.mutateAsync(body, {
+    const { data } = await postMyBottomSizeMutate.mutateAsync(body, {
       onSuccess() {
-        console.log(message);
+        console.log(data);
         onSuccessPost();
       },
     });

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -25,7 +25,6 @@ export default function App({ Component, pageProps }: AppProps) {
           </GoogleOAuthProvider>
         </RecoilRoot>
       </AsyncBoundary>
-      <div id="modal-root"></div>
     </QueryClientProvider>
   );
 }

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -19,6 +19,7 @@ export default function Document() {
       <body>
         <Main />
         <NextScript />
+        <div id="modal-root"></div>
       </body>
     </Html>
   );

--- a/pages/login/index.tsx
+++ b/pages/login/index.tsx
@@ -13,12 +13,14 @@ import Layout from 'components/common/Layout';
 function Login() {
   const [accessToken, setAccessToken] = useRecoilState(accessTokenState);
   const login = useGoogleLogin({
-    onSuccess: (response) => {
+    onSuccess: ({ code }) => {
       // recoil에 토큰들 저장하기
-      setAccessToken(response.access_token);
+      // setAccessToken(response.access_token);
       // 서버에 액세스 토큰 넘기기
       // useLoginMutation(accessToken);
+      console.log(code);
     },
+    flow: 'auth-code',
   });
 
   return (

--- a/pages/register/index.tsx
+++ b/pages/register/index.tsx
@@ -12,18 +12,6 @@ import SizeOption from 'components/register/SizeOption';
 // 버튼 컴포넌트 전달을 위한 타입
 export type OptionType = '상/하의' | '상의' | '하의' | null;
 
-interface iNextFormMapper {
-  '상/하의': OptionType;
-  상의: OptionType;
-  하의: OptionType;
-}
-
-const nextFormMapper: iNextFormMapper = {
-  '상/하의': '하의',
-  상의: '하의',
-  하의: '상의',
-};
-
 function Register() {
   const [progress, setProgress] = useState<number>(1);
   const [selectedOption, setSelectedOption] = useState<OptionType>(null);

--- a/pages/register/index.tsx
+++ b/pages/register/index.tsx
@@ -77,7 +77,7 @@ function Register() {
             <SizeForm
               isAlertActive={isAlertActive}
               setIsAlertActive={setIsAlertActive}
-              formType={selectedOption}
+              formType={selectedOption === '하의' ? '하의' : '상의'}
               setIsSubmitActive={setIsNextActive}
               onSuccessSubmit={onSuccessSubmit}
             >
@@ -87,7 +87,7 @@ function Register() {
             <SizeForm
               isAlertActive={isAlertActive}
               setIsAlertActive={setIsAlertActive}
-              formType={nextFormMapper[selectedOption]}
+              formType={selectedOption === '하의' ? '상의' : '하의'}
               setIsSubmitActive={setIsNextActive}
               onSuccessSubmit={onSuccessSubmit}
             >

--- a/pages/register/index.tsx
+++ b/pages/register/index.tsx
@@ -1,7 +1,9 @@
-import React, { useRef, useState } from 'react';
+import React, { useState } from 'react';
+import { useRouter } from 'next/router';
 import styled from 'styled-components';
 import theme from 'styles/theme';
 
+import NextButton from '@/components/register/NextButton';
 import Layout from 'components/common/Layout';
 import SizeForm from 'components/common/SizeForm/SizeForm';
 import Progress from 'components/register/Progress';
@@ -9,7 +11,6 @@ import SizeOption from 'components/register/SizeOption';
 
 // 버튼 컴포넌트 전달을 위한 타입
 export type OptionType = '상/하의' | '상의' | '하의' | null;
-export type ProgressType = 1 | 2 | 3;
 
 interface iNextFormMapper {
   '상/하의': OptionType;
@@ -27,7 +28,8 @@ function Register() {
   const [progress, setProgress] = useState<number>(1);
   const [selectedOption, setSelectedOption] = useState<OptionType>(null);
   const [isNextActive, setIsNextActive] = useState<boolean>(false);
-  const rootRef = useRef(null);
+  const [isAlertActive, setIsAlertActive] = useState<boolean>(false);
+  const router = useRouter();
 
   const onClickSize = () => {
     if (progress === 3) {
@@ -38,9 +40,21 @@ function Register() {
     }
   };
 
+  const onClickNextButton = () => {
+    setIsAlertActive(true);
+  };
+
+  const onSuccessSubmit = () => {
+    if (progress === 2) {
+      setProgress(progress + 1);
+    } else {
+      router.push('/home');
+    }
+  };
+
   return (
     <Layout noHeader noMenuBar>
-      <Styled.Root ref={rootRef}>
+      <Styled.Root>
         <Styled.LeftConatiner>
           <h1>Log In</h1>
           <h2>
@@ -61,20 +75,24 @@ function Register() {
             />
           ) : progress === 2 ? (
             <SizeForm
+              isAlertActive={isAlertActive}
+              setIsAlertActive={setIsAlertActive}
               formType={selectedOption}
-              isNextActive={isNextActive}
-              setIsNextActive={setIsNextActive}
-              progress={progress}
-              setProgress={setProgress}
-            />
+              setIsSubmitActive={setIsNextActive}
+              onSuccessSubmit={onSuccessSubmit}
+            >
+              <NextButton isActive={isNextActive} onClick={onClickNextButton} />
+            </SizeForm>
           ) : (
             <SizeForm
-              formType={selectedOption && nextFormMapper[selectedOption]}
-              isNextActive={isNextActive}
-              setIsNextActive={setIsNextActive}
-              progress={progress}
-              setProgress={setProgress}
-            />
+              isAlertActive={isAlertActive}
+              setIsAlertActive={setIsAlertActive}
+              formType={nextFormMapper[selectedOption]}
+              setIsSubmitActive={setIsNextActive}
+              onSuccessSubmit={onSuccessSubmit}
+            >
+              <NextButton isActive={isNextActive} onClick={onClickNextButton} />
+            </SizeForm>
           )}
         </Styled.RightContainer>
       </Styled.Root>

--- a/types/mySize/client.ts
+++ b/types/mySize/client.ts
@@ -2,6 +2,7 @@ export interface TopSizeInput {
   topLength: number;
   shoulder: number;
   chest: number;
+  isWidthOfTop: boolean;
 }
 
 export interface BottomSizeInput {
@@ -10,6 +11,7 @@ export interface BottomSizeInput {
   thigh: number;
   rise: number;
   hem: number;
+  isWidthOfBottom: boolean;
 }
 
 export interface MySizeOutput {


### PR DESCRIPTION
## 이슈 넘버
- close #36 
<!-- # 뒤에 이슈넘버를 써서 이슈를 닫아주세요 -->

## Need Review
- 회원가입과 mySize 두 뷰 모두에서 사용 가능하게끔 컴포넌트화 시켰습니다. 전달해주어야 하는 props는 다음과 같습니다.
```tsx
interface FormProps {
  noHeader?: boolean;
  formType: OptionType;
  isAlertActive: boolean;
  setIsAlertActive: (prev: boolean) => void;
  setIsSubmitActive?: (prev: boolean) => void;
  onSuccessSubmit: () => void;
  children: ReactNode;
}
```
- `noHeader`: 회원가입 뷰에서는 제목이 표시되어야 해서 제목을 넣어두었습니다. mySize 뷰에서는 noHeader 전달해주면 헤더가 표시되지 않습니다.
<img width="255" alt="image" src="https://user-images.githubusercontent.com/65955748/211267050-df74ac7a-530c-4a82-a32f-0514a277866a.png">

- `formType` : '상의'를 전달하면 상의 사이즈 입력 폼이, '하의'를 전달하면 하의 사이즈 입력 폼이 렌더링됩니다.
- `isAlertActive, setIsAlertActive` : 사이즈 입력 오류시 뜨는 Alert창의 여부에 대한 state, setState 함수입니다. 이부분은 컴포넌트 내에서 처리하고 싶었는데, 너무 복잡해져서 어쩔 수 없이 이 방법을 택했습니다. 아래 코드와 같이 사이즈 폼을 렌더링하는 페이지에서 boolean state를 선언해서 전달만 해주면 alert창이 뜹니다.
<img width="565" alt="image" src="https://user-images.githubusercontent.com/65955748/211267370-161e03b1-cdc9-4c18-8b11-decf1da1651b.png">

- `setIsSubmitActive` : @borimong 이부분은 구두로 설명해줄게!
- `onSuccessSubmit` : 사이즈 입력 post가 성공했을 때 호출될 함수를 적어주시면 됩니다. 저 같은 경우에는 router로 다음 화면으로 넘어가는 함수를 넣어주었습니다.
<img width="261" alt="image" src="https://user-images.githubusercontent.com/65955748/211268496-4f1e09c9-dbe8-4c7c-9194-b6774cac555f.png">

- `children` : 제출 버튼을 position: fixed로 만들어서 Form으로 감싸주시면 됩니다!
<img width="563" alt="image" src="https://user-images.githubusercontent.com/65955748/211269559-de70bea1-e89a-4c39-a8d0-cd088d7a54b9.png">

