### PR TITLE
QA 이슈 해결 (회원가입 단계 이슈, 카테고리 만들기, 수정 모달 input outline 이슈)

### DIFF
--- a/components/category/ModifyCategoryModal.tsx
+++ b/components/category/ModifyCategoryModal.tsx
@@ -121,6 +121,9 @@ const Styled = {
     padding-left: 2.4rem;
     ${theme.fonts.body1};
     color: ${theme.colors.gray550};
+    :focus {
+      outline: none;
+    }
     ::-webkit-input-placeholder {
       ${theme.fonts.body1};
       color: ${theme.colors.gray250};

--- a/components/common/SizeForm/SizeForm.tsx
+++ b/components/common/SizeForm/SizeForm.tsx
@@ -223,6 +223,7 @@ export default function SizeForm(props: FormProps) {
               data={data}
               isTopClicked={isTopClicked}
               hasToastOpened={hasToastOpened}
+              formType={formType}
             />
           ))}
           <Styled.RadioContainer>
@@ -271,6 +272,7 @@ export default function SizeForm(props: FormProps) {
               data={data}
               isTopClicked={isTopClicked}
               hasToastOpened={hasToastOpened}
+              formType={formType}
             />
           ))}
           <Styled.RadioContainer>

--- a/components/common/SizeForm/SizeInput.tsx
+++ b/components/common/SizeForm/SizeInput.tsx
@@ -39,7 +39,6 @@ function SizeInput(props: InputProps) {
 
   useEffect(() => {
     if (!data) return;
-
     if (data[inputKey] === null || data[inputKey] === 0) {
       //저장된 값이 없을 때
       setInputValue('');

--- a/components/common/SizeForm/SizeInput.tsx
+++ b/components/common/SizeForm/SizeInput.tsx
@@ -39,6 +39,7 @@ function SizeInput(props: InputProps) {
 
   useEffect(() => {
     if (!data) return;
+
     if (data[inputKey] === null || data[inputKey] === 0) {
       //저장된 값이 없을 때
       setInputValue('');

--- a/components/common/SizeForm/SizeInput.tsx
+++ b/components/common/SizeForm/SizeInput.tsx
@@ -28,15 +28,15 @@ interface InputProps {
   data?: DataType;
   isTopClicked?: boolean;
   hasToastOpened?: boolean;
+  formType?: string | null;
 }
 
 function SizeInput(props: InputProps) {
-  const { inputKey, measure, register, setValue, valid, data, isTopClicked, hasToastOpened } = props;
+  const { inputKey, measure, register, setValue, valid, data, isTopClicked, formType } = props;
   const label = measure ? `${inputKey} ${measure}` : `${inputKey}`;
 
   const [inputValue, setInputValue] = useState('');
   const [hasInputValueChanged, setHasInputValueChanged] = useState(false);
-
   useEffect(() => {
     if (!data) return;
 
@@ -57,6 +57,12 @@ function SizeInput(props: InputProps) {
     setHasInputValueChanged(false);
   }, [isTopClicked, measure]);
 
+  useEffect(() => {
+    if(!data){
+    setInputValue('');
+    }
+  }, [measure, formType])
+
   return (
     <Styled.InputContainer key={inputKey}>
       <label>{label}</label>
@@ -64,7 +70,7 @@ function SizeInput(props: InputProps) {
         <Styled.Input
           type="number"
           step="0.1"
-          value={data && inputValue}
+          value={inputValue}
           {...register(inputKey, {
             required: true,
             validate: (value) =>

--- a/components/common/modal/CategoryCreateModal.tsx
+++ b/components/common/modal/CategoryCreateModal.tsx
@@ -109,6 +109,9 @@ const Styled = {
     padding-left: 2.4rem;
     ${theme.fonts.body1};
     color: ${theme.colors.gray550};
+    :focus {
+      outline: none;
+    }
     ::-webkit-input-placeholder {
       ${theme.fonts.body1};
       color: ${theme.colors.gray250};

--- a/components/mysize/Mysize.tsx
+++ b/components/mysize/Mysize.tsx
@@ -35,7 +35,6 @@ export default function Mysize() {
     setIsAlertActive(true);
   };
 
-
   //토스트
   const { isOpenToast, message, showToast } = useToast();
   const [hasToastOpened, setHasToastOpened] = useState(false);
@@ -43,7 +42,6 @@ export default function Mysize() {
     showToast('저장되었습니다.');
     setHasToastOpened(true);
   };
-
 
   //클릭 상태 관리
   const [topColor, setTopColor] = useState(`${theme.colors.black}`);
@@ -54,7 +52,6 @@ export default function Mysize() {
 
   //데이터 패칭
   const { allMysize } = useFetchMysize(isTopClicked, clickedMeasure);
-
 
   const onClickMeasure = (measure: string) => {
     setClickedMeasure(measure);
@@ -162,7 +159,6 @@ export default function Mysize() {
       }
     }
   }, [allMysize, isTopClicked, clickedMeasure]);
-
 
   return (
     <Styled.Root>

--- a/hooks/queries/mypageHistory.ts
+++ b/hooks/queries/mypageHistory.ts
@@ -1,5 +1,4 @@
 import { useMutation, useQuery, useQueryClient } from 'react-query';
-
 import { fetchUserInformation, fetchMyPageHistory } from '../../apis/mypageHistory';
 
 const QUERY_KEY = {


### PR DESCRIPTION
## 이슈 넘버
- close #118
<!-- # 뒤에 이슈넘버를 써서 이슈를 닫아주세요 -->

## 구현 사항
<!-- 실제로 변경한 사항을 설명해주세요.-->
- [ ] ex. 랜딩페이지 헤더 구현
- [x] 카테고리 만들기/수정 모달의 input outline 없애기
- [x] 회원가입 단계에서 둘레/단면 전환 시 입력값 초기화

## Need Review
- ~ 부분 이렇게 구현했어요, 피드백 부탁해요!
<!-- 어떤 부분에 리뷰어가 집중해야 하는지 or 해당 PR에서 논의가 필요한 사항을 적어주세요. -->
1. components/common/modal/CategoryCreateModal.tsx, components/category/ModifyCategoryModal.tsx
input 태그에 다음 속성을 추가해서 focus 시에 파란색 테두리가 생기지 않게 했습니다!
```
:focus {
      outline: none;
    }

```
2. components/common/SizeForm/SizeInput.tsx
1) measure 를 의존성 배열에 넣은 useEffect 를 만들어 measure 값이 바뀌면 input 필드가 초기화가 되도록 조치하고, 
```
useEffect(() => {
    setInputValue('');
  }, [measure])
```
2) 기존에는 data 가 있어야 value 에 inputValue 를 넣었었는데, data 가 없어서 InputValue 가 세팅될 수 있게 코드 수정,
```
 <Styled.Input
          type="number"
          step="0.1"
          value={inputValue}
```
3) data && 를 지웠으므로, 회원가입 단계에서 상의 입력 후 하의 클릭 시, 총장에 값이 그대로 남아있는 문제가 생기므로 (inputKey 가 같아서 useEffect 가 실행되지 않음) 상/하의를 구별해주는 formType 을 props 로 전달받아 measure 와 함께 써주고, 
```
useEffect(() => {
    setInputValue('');
  }, [measure, formType])
```
4) 마지막으로 if(!data) 조건을 넣어서, 마이사이즈에서는 해당 useEffect 가 실행되지 않도록 해주었어요!
```
useEffect(() => {
    if(!data){
    setInputValue('');
    }
  }, [measure, **formType**])
```
## 📸 스크린샷
<!-- 팀원들이 이해하기 쉽도록 스크린샷을 첨부해주세요. -->

https://user-images.githubusercontent.com/86764406/218264400-1ca34798-b85f-43cd-bcc9-34f6d4cec451.mov


## Reference
<!-- 참고한 사이트가 있다면 링크를 공유해주세요. -->
