### PR TITLE
fix: 소숫점 아래 한 자리 수로 통일, 저장 버튼 연속 클릭 시에도 정상 작동하게 fix함

### DIFF
--- a/components/common/SizeForm/SizeForm.tsx
+++ b/components/common/SizeForm/SizeForm.tsx
@@ -130,7 +130,6 @@ export default function SizeForm(props: FormProps) {
   const { postMyBottomSize } = usePostMyBottomSize();
 
   const onValid: SubmitHandler<FieldValues> = async (data: FieldValues) => {
-    console.log(data);
     setIsAlertActive(false);
     if (formType === '상의') {
       const inputData: TopSizeInput = {
@@ -163,7 +162,7 @@ export default function SizeForm(props: FormProps) {
       };
 
       Object.entries(mutateMapper.bottom).map(([kor, eng]) => {
-        inputData[eng] = parseFloat(data[kor]);
+        inputData[eng] = Number(parseFloat(data[kor]).toFixed(1));
       });
 
       if (measure === '둘레') {
@@ -224,6 +223,7 @@ export default function SizeForm(props: FormProps) {
               isTopClicked={isTopClicked}
               hasToastOpened={hasToastOpened}
               formType={formType}
+              isAlertActive={isAlertActive}
             />
           ))}
           <Styled.RadioContainer>
@@ -255,6 +255,7 @@ export default function SizeForm(props: FormProps) {
               data={data}
               isTopClicked={isTopClicked}
               hasToastOpened={hasToastOpened}
+              isAlertActive={isAlertActive}
             />
           ))}
           {children}
@@ -273,6 +274,7 @@ export default function SizeForm(props: FormProps) {
               isTopClicked={isTopClicked}
               hasToastOpened={hasToastOpened}
               formType={formType}
+              isAlertActive={isAlertActive}
             />
           ))}
           <Styled.RadioContainer>
@@ -302,6 +304,7 @@ export default function SizeForm(props: FormProps) {
             data={data}
             isTopClicked={isTopClicked}
             hasToastOpened={hasToastOpened}
+            isAlertActive={isAlertActive}
           />
           {children}
         </Styled.Form>

--- a/components/common/SizeForm/SizeInput.tsx
+++ b/components/common/SizeForm/SizeInput.tsx
@@ -29,10 +29,11 @@ interface InputProps {
   isTopClicked?: boolean;
   hasToastOpened?: boolean;
   formType?: string | null;
+  isAlertActive?: boolean;
 }
 
 function SizeInput(props: InputProps) {
-  const { inputKey, measure, register, setValue, valid, data, isTopClicked, formType } = props;
+  const { inputKey, measure, register, setValue, valid, data, isTopClicked, formType, isAlertActive } = props;
   const label = measure ? `${inputKey} ${measure}` : `${inputKey}`;
 
   const [inputValue, setInputValue] = useState('');
@@ -45,13 +46,14 @@ function SizeInput(props: InputProps) {
       setInputValue('');
     } else if (!hasInputValueChanged) {
       //유저가 저장된 값을 변경한 적이 없을 때
-      setInputValue(`${data[inputKey]}`);
+      setInputValue(parseFloat(`${data[inputKey]}`).toFixed(1));
       setValue(inputKey, parseFloat(`${data[inputKey]}`).toFixed(1));
     } else {
       //유저가 저장된 값을 변경했을 때
-      setInputValue(inputValue);
+      setInputValue(parseFloat(inputValue).toFixed(1));
+      setValue(inputKey, parseFloat(inputValue).toFixed(1));
     }
-  }, [data, inputKey]);
+  }, [data, inputKey, isAlertActive]);
 
   useEffect(() => {
     setHasInputValueChanged(false);

--- a/components/mypage/MypageMain.tsx
+++ b/components/mypage/MypageMain.tsx
@@ -5,7 +5,6 @@ import Image from 'next/image';
 import styled from 'styled-components';
 import theme from 'styles/theme';
 
-import { useAuth } from '@/hooks/business/user';
 import Modal from 'components/common/Modal';
 import ModalPortal from 'components/common/modal/ModalPortal';
 
@@ -17,7 +16,6 @@ function MyPageMain() {
   const [isHistoryModalOpen, setIsHistoryModalOpen] = useState(false);
   const [isLeaveModalOpen, setIsLeaveModalOpen] = useState(false);
   const [isButtonActivated, setIsButtonActivated] = useState(true);
-  const { authLogout } = useAuth();
 
   const onClickHistoryModal = () => {
     setIsHistoryModalOpen(!isHistoryModalOpen);
@@ -78,9 +76,7 @@ function MyPageMain() {
           <button className="withdrawal" onClick={onClickLeaveModal}>
             탈퇴하기
           </button>
-          <button className="signOut" onClick={authLogout}>
-            로그아웃
-          </button>
+          <button className="signOut">로그아웃</button>
         </Styled.UserLeaveContainer>
       </Styled.MySizeContainer>
       {isHistoryModalOpen && (


### PR DESCRIPTION
## 이슈 넘버
- close #120
<!-- # 뒤에 이슈넘버를 써서 이슈를 닫아주세요 -->

## 구현 사항
<!-- 실제로 변경한 사항을 설명해주세요.-->
- [ ] ex. 랜딩페이지 헤더 구현
- [ ] 마이사이즈에서 입력값이 정수여도 소숫점 아래 한 자리로 나오게끔 조정
- [ ] 마이사이즈에서 저장하기를 연속해서 누르면 두 번째부터는 저장되지 않는 이슈가 있었는데 해결


## Need Review
- ~ 부분 이렇게 구현했어요, 피드백 부탁해요!
<!-- 어떤 부분에 리뷰어가 집중해야 하는지 or 해당 PR에서 논의가 필요한 사항을 적어주세요. -->
1. 소숫점 이슈 -> 정수여도 소숫점 아래 한 자리까지 보여주어야 함. (ex. 44 -> 44.0 으로 변환하여 보여주기)
common/SizeForm/SizeInput.tsx
다음과 같이 setValue 에 parseFloat.toFixed(1)를 붙여주어 해결했습니다!
```
if (data[inputKey] === null || data[inputKey] === 0) {
      //저장된 값이 없을 때
      setInputValue('');
    } else if (!hasInputValueChanged) {
      //유저가 저장된 값을 변경한 적이 없을 때
      setInputValue(parseFloat(`${data[inputKey]}`).toFixed(1));
      setValue(inputKey, parseFloat(`${data[inputKey]}`).toFixed(1));
    } else {
      //유저가 저장된 값을 변경했을 때
      setInputValue(parseFloat(inputValue).toFixed(1));
      setValue(inputKey, parseFloat(inputValue).toFixed(1));
    }
```
2. 마이사이즈 연속 저장 이슈
인풋의 value, 다시 말해 inputValue 를 set 하는 useEffect 의 의존성 배열에, 저장 버튼이 눌렸음을 알리는 상태, isAlertActive 를 넣음으로써 연속 저장 시에도 value 에 값이 들어있게끔 조치했습니다!
```
useEffect(() => {
    if (!data) return;

    if (data[inputKey] === null || data[inputKey] === 0) {
      //저장된 값이 없을 때
      setInputValue('');
    ...생략
  }, [data, inputKey, isAlertActive]);
```
## 📸 스크린샷
<!-- 팀원들이 이해하기 쉽도록 스크린샷을 첨부해주세요. -->

https://user-images.githubusercontent.com/86764406/218567856-c7a26920-d14a-4a5e-8e3e-b337ad0b0f68.mov


## Reference
<!-- 참고한 사이트가 있다면 링크를 공유해주세요. -->
