### PR TITLE
fix: 마이페이지 히스토리 모달 성능 최적화 및 마이사이즈 네트워크 로딩 최적화

### DIFF
--- a/components/common/SizeForm/SizeForm.tsx
+++ b/components/common/SizeForm/SizeForm.tsx
@@ -31,7 +31,6 @@ interface FormProps {
     | { 총장: number; '어깨 너비': number; 가슴: number }
     | { 총장: number; 밑위: number; 허리: number; 허벅지: number; 밑단: number };
   isTopClicked?: boolean;
-  hasToastOpened?: boolean;
 }
 
 // 상의 총장, 어깨너비
@@ -98,7 +97,6 @@ export default function SizeForm(props: FormProps) {
     onClickMeasure,
     data,
     isTopClicked,
-    hasToastOpened,
   } = props;
   const [measure, setMeasure] = useState<'단면' | '둘레'>('단면');
 
@@ -219,7 +217,6 @@ export default function SizeForm(props: FormProps) {
               valid={{ min, max }}
               data={data}
               isTopClicked={isTopClicked}
-              hasToastOpened={hasToastOpened}
               formType={formType}
               isAlertActive={isAlertActive}
             />
@@ -252,7 +249,6 @@ export default function SizeForm(props: FormProps) {
               valid={{ min: scope[measure].min, max: scope[measure].max }}
               data={data}
               isTopClicked={isTopClicked}
-              hasToastOpened={hasToastOpened}
               isAlertActive={isAlertActive}
             />
           ))}
@@ -270,7 +266,6 @@ export default function SizeForm(props: FormProps) {
               valid={{ min, max }}
               data={data}
               isTopClicked={isTopClicked}
-              hasToastOpened={hasToastOpened}
               formType={formType}
               isAlertActive={isAlertActive}
             />
@@ -301,7 +296,6 @@ export default function SizeForm(props: FormProps) {
             valid={{ min: chestScopeMapper[measure].min, max: chestScopeMapper[measure].max }}
             data={data}
             isTopClicked={isTopClicked}
-            hasToastOpened={hasToastOpened}
             isAlertActive={isAlertActive}
           />
           {children}

--- a/components/common/SizeForm/SizeInput.tsx
+++ b/components/common/SizeForm/SizeInput.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { FieldValues, UseFormRegister, UseFormSetValue } from 'react-hook-form';
 import styled from 'styled-components';
 import theme from 'styles/theme';
@@ -27,7 +27,6 @@ interface InputProps {
   valid: { min: number; max: number };
   data?: DataType;
   isTopClicked?: boolean;
-  hasToastOpened?: boolean;
   formType?: string | null;
   isAlertActive?: boolean;
 }
@@ -60,10 +59,10 @@ function SizeInput(props: InputProps) {
   }, [isTopClicked, measure]);
 
   useEffect(() => {
-    if(!data){
-    setInputValue('');
+    if (!data) {
+      setInputValue('');
     }
-  }, [measure, formType])
+  }, [measure, formType]);
 
   return (
     <Styled.InputContainer key={inputKey}>

--- a/components/mypage/MypageMain.tsx
+++ b/components/mypage/MypageMain.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, lazy, Suspense } from 'react';
 import profileDefault from 'assets/icon/profileDefault.svg';
 import sizeReplacement from 'assets/icon/sizeReplacement.png';
 import Image from 'next/image';
@@ -14,7 +14,7 @@ import ModalPortal from 'components/common/modal/ModalPortal';
 
 import { useFetchMyPageHistory, useFetchUserInformation } from '../../hooks/queries/mypageHistory';
 
-import HistoryModal from './HistoryModal';
+const HistoryModal = lazy(() => import('./HistoryModal'));
 
 function MyPageMain() {
   const [isHistoryModalOpen, setIsHistoryModalOpen] = useState(false);
@@ -59,8 +59,8 @@ function MyPageMain() {
       <Styled.MySizeContainer>
         <Styled.UserInformationContainer>
           <Image
-            src={profileDefault}
-            alt="사용자 지정 프로필 이미지가 없는 경우의 디폴트 프로필 이미지"
+            src={userInformation ? userInformation.picture : profileDefault}
+            alt="사용자 프로필 이미지"
             width={82}
             height={82}
             placeholder="blur"
@@ -78,20 +78,26 @@ function MyPageMain() {
         </Styled.History>
         <Styled.InformationContainer>
           <h1>정보</h1>
-          <p
-            onClick={() =>
-              window.open(
-                'https://docs.google.com/forms/d/e/1FAIpQLSfHXvABOrKUtbROS1Qm3pm-YdQG4_9QwoXMiucclvOsz7VrMQ/viewform',
-                '_blank'
-              )
-            }
-          >
-            피드백 및 버그 제보
+          <p>
+            <span
+              onClick={() => {
+                window.open(
+                  'https://docs.google.com/forms/d/e/1FAIpQLSfHXvABOrKUtbROS1Qm3pm-YdQG4_9QwoXMiucclvOsz7VrMQ/viewform',
+                  '_blank'
+                );
+              }}
+            >
+              피드백 및 버그 제보
+            </span>
           </p>
-          <p
-            onClick={() => window.open('https://golden-rib-2f1.notion.site/7171b098f7c94b04b136702f24e198b6', '_blank')}
-          >
-            개인 정보 보호 정책
+          <p>
+            <span
+              onClick={() => {
+                window.open('https://golden-rib-2f1.notion.site/7171b098f7c94b04b136702f24e198b6', '_blank');
+              }}
+            >
+              개인 정보 보호 정책
+            </span>
           </p>
         </Styled.InformationContainer>
         <Styled.UserLeaveContainer>
@@ -104,30 +110,38 @@ function MyPageMain() {
         </Styled.UserLeaveContainer>
       </Styled.MySizeContainer>
       {isHistoryModalOpen && (
-        <ModalPortal>
-          <HistoryModal onClickHistoryModal={onClickHistoryModal}>
-            {history &&
-              history.recData.map((history) => (
-                <Styled.HistoryModalLink key={history.id}>
-                  {history.recommendSize === '-' ? (
-                    <div>
-                      <Image
-                        src={sizeReplacement}
-                        alt="추천받은 사이즈가 없는 경우, 없음을 나타내는 이미지"
-                        width={6}
-                        height={6}
-                        placeholder="blur"
-                        blurDataURL="assets/icon/sizeReplacement.png"
-                      ></Image>
-                    </div>
-                  ) : (
-                    <h5>{history.recommendSize}</h5>
-                  )}
-                  <p onClick={() => window.open(history.url, '_blank')}>{history.url.substr(0, 17)}</p>
-                </Styled.HistoryModalLink>
-              ))}
-          </HistoryModal>
-        </ModalPortal>
+        <Suspense fallback={<div>로딩중</div>}>
+          <ModalPortal>
+            <HistoryModal onClickHistoryModal={onClickHistoryModal}>
+              {history &&
+                history.recData.map((history) => (
+                  <Styled.HistoryModalLink key={history.id}>
+                    {history.recommendSize === '-' ? (
+                      <div>
+                        <Image
+                          src={sizeReplacement}
+                          alt="추천받은 사이즈가 없는 경우, 없음을 나타내는 이미지"
+                          width={6}
+                          height={6}
+                          placeholder="blur"
+                          blurDataURL="assets/icon/sizeReplacement.png"
+                        ></Image>
+                      </div>
+                    ) : (
+                      <h5>{history.recommendSize}</h5>
+                    )}
+                    <p
+                      onClick={() => {
+                        window.open(history.url, '_blank');
+                      }}
+                    >
+                      {history.url.substr(0, 17)}
+                    </p>
+                  </Styled.HistoryModalLink>
+                ))}
+            </HistoryModal>
+          </ModalPortal>
+        </Suspense>
       )}
       {isLeaveModalOpen && (
         <ModalPortal>
@@ -175,6 +189,9 @@ const Styled = {
     margin-bottom: 5.4rem;
     display: flex;
     flex-wrap: wrap;
+    & > img {
+      border-radius: 70%;
+    }
   `,
   UserInformation: styled.div`
     ${theme.fonts.title2}
@@ -230,7 +247,9 @@ const Styled = {
       ${theme.fonts.body7};
       color: ${theme.colors.gray550};
       margin-bottom: 3rem;
-      cursor: pointer;
+      & > span {
+        cursor: pointer;
+      }
     }
   `,
   UserLeaveContainer: styled.div`

--- a/components/mysize/Mysize.tsx
+++ b/components/mysize/Mysize.tsx
@@ -34,10 +34,8 @@ export default function Mysize() {
 
   //토스트
   const { isOpenToast, message, showToast } = useToast();
-  const [hasToastOpened, setHasToastOpened] = useState(false);
   const onSuccessSubmit = () => {
     showToast('저장되었습니다.');
-    setHasToastOpened(true);
   };
 
   //클릭 상태 관리
@@ -196,7 +194,6 @@ export default function Mysize() {
           onClickMeasure={onClickMeasure}
           data={data}
           isTopClicked={isTopClicked}
-          hasToastOpened={hasToastOpened}
         >
           <Styled.SaveButton onClick={handleClick} type="submit">
             저장

--- a/hooks/queries/mySize.ts
+++ b/hooks/queries/mySize.ts
@@ -10,9 +10,7 @@ const QUERY_KEY = {
 };
 
 export const useFetchMysize = (...args: unknown[]) => {
-  const { data } = useQuery([QUERY_KEY.allMysize, args], fetchMysize, {
-    refetchOnWindowFocus: true,
-  });
+  const { data } = useQuery([QUERY_KEY.allMysize, args], fetchMysize);
   return {
     allMysize: data,
   };

--- a/hooks/queries/mySize.ts
+++ b/hooks/queries/mySize.ts
@@ -10,7 +10,9 @@ const QUERY_KEY = {
 };
 
 export const useFetchMysize = (...args: unknown[]) => {
-  const { data } = useQuery([QUERY_KEY.allMysize, args], fetchMysize);
+  const { data } = useQuery([QUERY_KEY.allMysize, args], fetchMysize, {
+    refetchOnWindowFocus: true,
+  });
   return {
     allMysize: data,
   };


### PR DESCRIPTION
## 이슈 넘버
- close #126
<!-- # 뒤에 이슈넘버를 써서 이슈를 닫아주세요 -->

## 구현 사항
<!-- 실제로 변경한 사항을 설명해주세요.-->
- [ ] ex. 랜딩페이지 헤더 구현
- [ ] hasToastOpened state 더 이상 필요하지 않아서 제거
- [ ] 마이페이지 cursor: pointer 속성이 <p> 에 block 단위로 적용되었던 것을 span 단위로 변경
- [ ] 마이페이지 프로필 이미지 구글 프로필 이미지로 fetch 
- [ ] refetchOnWindowFocus 속성에 true 값을 줌으로써 성능 향상
- [ ] React lazy 이용해 동적 import / 코드 스플리팅


## Need Review
- ~ 부분 이렇게 구현했어요, 피드백 부탁해요!
<!-- 어떤 부분에 리뷰어가 집중해야 하는지 or 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

hooks/queries/mySize.ts 
refetchOnWindowFocus 속성(window 에 focus 되었을 때 자동으로 refetch 해주는 속성)에 true 를 주었더니 lighthouse 보고서에서 성능이 1만큼 향상되었습니다..! 그런데 디폴트값이 true 라고 하는데.. 그럼 안적어 주었을 때랑 적어주었을 때랑 차이가 없어야 하는데 왜 성능이 향상되었는지는 잘 모르겠습니다..
```
  const { data } = useQuery([QUERY_KEY.allMysize, args], fetchMysize, {
    refetchOnWindowFocus: true,
  });
```

components/mypage/MypageMain.tsx 
히스토리 모달은 안에서 데이터 패칭이 일어나기 때문에 리액트 lazy 를 이용해서 초기 렌더링에서 제외해 주면 반드시 성능이 높아질 것이라 생각했습니다! 그런데 profiler 로 렌더링을 측정한 결과.. 과연 성능이 좋아진 것인지는 잘 모르겠습니다..!ㅠㅠ(오히려 lazy 를 사용하지 않았을 때가 더 높게 나온 적도 있어서요..!) 그리고 모달 포탈을 이용해서 모달 포탈 보다 위에 Suspense 를 넣어주어야 히스토리 모달이 렌더링될 때 화면이 일그러지는 문제가 발생하지 않아서 이렇게 해 주었습니다..! 모달 포탈은 새 dom 을 만들어서 거기에 컴포넌트를 렌더링하기 때문에 이렇게 해야하지 않을까..? 라고 생각했습니다..! 
```
const HistoryModal = lazy(() => import('./HistoryModal'));
//생략
  <Suspense fallback={<div>로딩중</div>}>
          <ModalPortal>
            <HistoryModal onClickHistoryModal={onClickHistoryModal}>
```
## 📸 스크린샷
<!-- 팀원들이 이해하기 쉽도록 스크린샷을 첨부해주세요. -->
![image](https://user-images.githubusercontent.com/86764406/221503764-f2a4e557-724d-4648-a120-a1ae8ba0e514.png)
QA 중에 발견했는데.. 마이페이지 프로필 사진을 지금까지 계속 디폴트 이미지로 해두었더라구요!! 하하.. 그래서 바로 구글 프로필 이미지로 수정했습니다!
## Reference
<!-- 참고한 사이트가 있다면 링크를 공유해주세요. -->
