### PR TITLE
Feat/#137 입력하지 않은 의류 유형 수정 시 값 초기화되는 문제 해결, 하의만 입력 시 총장값 겹치는 문제 해결, 잘못된 값 입력 시 값 사라지는 문제, 단면 / 둘레 최초 활성화 기능 추가

### DIFF
--- a/components/common/SizeForm/SizeForm.tsx
+++ b/components/common/SizeForm/SizeForm.tsx
@@ -31,6 +31,7 @@ interface FormProps {
     | { 총장: number; '어깨 너비': number; 가슴: number }
     | { 총장: number; 밑위: number; 허리: number; 허벅지: number; 밑단: number };
   isTopClicked?: boolean;
+  isSaveButtonClicked?: boolean;
 }
 
 // 상의 총장, 어깨너비
@@ -97,6 +98,7 @@ export default function SizeForm(props: FormProps) {
     onClickMeasure,
     data,
     isTopClicked,
+    isSaveButtonClicked
   } = props;
   const [measure, setMeasure] = useState<'단면' | '둘레'>('단면');
 
@@ -219,6 +221,7 @@ export default function SizeForm(props: FormProps) {
               isTopClicked={isTopClicked}
               formType={formType}
               isAlertActive={isAlertActive}
+              isSaveButtonClicked={isSaveButtonClicked}
             />
           ))}
           <Styled.RadioContainer>
@@ -250,6 +253,7 @@ export default function SizeForm(props: FormProps) {
               data={data}
               isTopClicked={isTopClicked}
               isAlertActive={isAlertActive}
+              isSaveButtonClicked={isSaveButtonClicked}
             />
           ))}
           {children}
@@ -268,6 +272,7 @@ export default function SizeForm(props: FormProps) {
               isTopClicked={isTopClicked}
               formType={formType}
               isAlertActive={isAlertActive}
+              isSaveButtonClicked={isSaveButtonClicked}
             />
           ))}
           <Styled.RadioContainer>
@@ -297,6 +302,7 @@ export default function SizeForm(props: FormProps) {
             data={data}
             isTopClicked={isTopClicked}
             isAlertActive={isAlertActive}
+            isSaveButtonClicked={isSaveButtonClicked}
           />
           {children}
         </Styled.Form>

--- a/components/common/SizeForm/SizeForm.tsx
+++ b/components/common/SizeForm/SizeForm.tsx
@@ -31,9 +31,7 @@ interface FormProps {
     | { 총장: number; '어깨 너비': number; 가슴: number }
     | { 총장: number; 밑위: number; 허리: number; 허벅지: number; 밑단: number };
   isTopClicked?: boolean;
-  isOpenToast?: boolean;
   emptyClothesType?: string;
-  isSubmitActive?: boolean;
   isInitialValueWidth?: boolean;
 }
 
@@ -101,9 +99,7 @@ export default function SizeForm(props: FormProps) {
     onClickMeasure,
     data,
     isTopClicked,
-    isOpenToast,
     emptyClothesType,
-    isSubmitActive,
     isInitialValueWidth,
   } = props;
   const [measure, setMeasure] = useState<'단면' | '둘레'>('단면');
@@ -248,9 +244,7 @@ export default function SizeForm(props: FormProps) {
               isTopClicked={isTopClicked}
               formType={formType}
               isAlertActive={isAlertActive}
-              isOpenToast={isOpenToast}
               emptyClothesType={emptyClothesType}
-              isSubmitActive={isSubmitActive}
             />
           ))}
           <Styled.RadioContainer>
@@ -282,9 +276,7 @@ export default function SizeForm(props: FormProps) {
               data={data}
               isTopClicked={isTopClicked}
               isAlertActive={isAlertActive}
-              isOpenToast={isOpenToast}
               emptyClothesType={emptyClothesType}
-              isSubmitActive={isSubmitActive}
             />
           ))}
           {children}
@@ -303,9 +295,7 @@ export default function SizeForm(props: FormProps) {
               isTopClicked={isTopClicked}
               formType={formType}
               isAlertActive={isAlertActive}
-              isOpenToast={isOpenToast}
               emptyClothesType={emptyClothesType}
-              isSubmitActive={isSubmitActive}
             />
           ))}
           <Styled.RadioContainer>
@@ -335,9 +325,7 @@ export default function SizeForm(props: FormProps) {
             data={data}
             isTopClicked={isTopClicked}
             isAlertActive={isAlertActive}
-            isOpenToast={isOpenToast}
             emptyClothesType={emptyClothesType}
-            isSubmitActive={isSubmitActive}
           />
           {children}
         </Styled.Form>

--- a/components/common/SizeForm/SizeForm.tsx
+++ b/components/common/SizeForm/SizeForm.tsx
@@ -31,6 +31,9 @@ interface FormProps {
     | { 총장: number; '어깨 너비': number; 가슴: number }
     | { 총장: number; 밑위: number; 허리: number; 허벅지: number; 밑단: number };
   isTopClicked?: boolean;
+  isOpenToast?: boolean;
+  emptyClothesType?: string;
+  isSubmitActive?: boolean;
 }
 
 // 상의 총장, 어깨너비
@@ -97,6 +100,9 @@ export default function SizeForm(props: FormProps) {
     onClickMeasure,
     data,
     isTopClicked,
+    isOpenToast,
+    emptyClothesType,
+    isSubmitActive,
   } = props;
   const [measure, setMeasure] = useState<'단면' | '둘레'>('단면');
 
@@ -225,6 +231,9 @@ export default function SizeForm(props: FormProps) {
               isTopClicked={isTopClicked}
               formType={formType}
               isAlertActive={isAlertActive}
+              isOpenToast={isOpenToast}
+              emptyClothesType={emptyClothesType}
+              isSubmitActive={isSubmitActive}
             />
           ))}
           <Styled.RadioContainer>
@@ -256,6 +265,10 @@ export default function SizeForm(props: FormProps) {
               data={data}
               isTopClicked={isTopClicked}
               isAlertActive={isAlertActive}
+              isOpenToast={isOpenToast}
+              emptyClothesType={emptyClothesType}
+              isSubmitActive={isSubmitActive}
+
             />
           ))}
           {children}
@@ -274,6 +287,10 @@ export default function SizeForm(props: FormProps) {
               isTopClicked={isTopClicked}
               formType={formType}
               isAlertActive={isAlertActive}
+              isOpenToast={isOpenToast}
+              emptyClothesType={emptyClothesType}
+              isSubmitActive={isSubmitActive}
+
             />
           ))}
           <Styled.RadioContainer>
@@ -303,6 +320,10 @@ export default function SizeForm(props: FormProps) {
             data={data}
             isTopClicked={isTopClicked}
             isAlertActive={isAlertActive}
+            isOpenToast={isOpenToast}
+            emptyClothesType={emptyClothesType}
+            isSubmitActive={isSubmitActive}
+
           />
           {children}
         </Styled.Form>

--- a/components/common/SizeForm/SizeForm.tsx
+++ b/components/common/SizeForm/SizeForm.tsx
@@ -34,6 +34,7 @@ interface FormProps {
   isOpenToast?: boolean;
   emptyClothesType?: string;
   isSubmitActive?: boolean;
+  isInitialValueWidth?: boolean;
 }
 
 // 상의 총장, 어깨너비
@@ -103,6 +104,7 @@ export default function SizeForm(props: FormProps) {
     isOpenToast,
     emptyClothesType,
     isSubmitActive,
+    isInitialValueWidth,
   } = props;
   const [measure, setMeasure] = useState<'단면' | '둘레'>('단면');
 
@@ -214,6 +216,21 @@ export default function SizeForm(props: FormProps) {
     onClickMeasure && onClickMeasure(measure);
   };
 
+  //마이사이즈 단면 / 둘레 최초 활성화
+  useEffect(() => {
+    if (isInitialValueWidth) {
+      setMeasure('단면');
+      sendMeasureValue('단면');
+    } else if(isInitialValueWidth === false){
+      setMeasure('둘레');
+      sendMeasureValue('둘레');
+    } 
+    else {
+      setMeasure('단면');
+      sendMeasureValue('단면');
+    }
+  }, [isTopClicked, formType, isInitialValueWidth]);
+
   return (
     <Styled.Root>
       {!noHeader && formType && <Styled.Header>{formType} 사이즈를 입력해주세요</Styled.Header>}
@@ -268,7 +285,6 @@ export default function SizeForm(props: FormProps) {
               isOpenToast={isOpenToast}
               emptyClothesType={emptyClothesType}
               isSubmitActive={isSubmitActive}
-
             />
           ))}
           {children}
@@ -290,7 +306,6 @@ export default function SizeForm(props: FormProps) {
               isOpenToast={isOpenToast}
               emptyClothesType={emptyClothesType}
               isSubmitActive={isSubmitActive}
-
             />
           ))}
           <Styled.RadioContainer>
@@ -323,7 +338,6 @@ export default function SizeForm(props: FormProps) {
             isOpenToast={isOpenToast}
             emptyClothesType={emptyClothesType}
             isSubmitActive={isSubmitActive}
-
           />
           {children}
         </Styled.Form>

--- a/components/common/SizeForm/SizeForm.tsx
+++ b/components/common/SizeForm/SizeForm.tsx
@@ -31,7 +31,6 @@ interface FormProps {
     | { 총장: number; '어깨 너비': number; 가슴: number }
     | { 총장: number; 밑위: number; 허리: number; 허벅지: number; 밑단: number };
   isTopClicked?: boolean;
-  isSaveButtonClicked?: boolean;
 }
 
 // 상의 총장, 어깨너비
@@ -98,7 +97,6 @@ export default function SizeForm(props: FormProps) {
     onClickMeasure,
     data,
     isTopClicked,
-    isSaveButtonClicked
   } = props;
   const [measure, setMeasure] = useState<'단면' | '둘레'>('단면');
 
@@ -221,7 +219,6 @@ export default function SizeForm(props: FormProps) {
               isTopClicked={isTopClicked}
               formType={formType}
               isAlertActive={isAlertActive}
-              isSaveButtonClicked={isSaveButtonClicked}
             />
           ))}
           <Styled.RadioContainer>
@@ -253,7 +250,6 @@ export default function SizeForm(props: FormProps) {
               data={data}
               isTopClicked={isTopClicked}
               isAlertActive={isAlertActive}
-              isSaveButtonClicked={isSaveButtonClicked}
             />
           ))}
           {children}
@@ -272,7 +268,6 @@ export default function SizeForm(props: FormProps) {
               isTopClicked={isTopClicked}
               formType={formType}
               isAlertActive={isAlertActive}
-              isSaveButtonClicked={isSaveButtonClicked}
             />
           ))}
           <Styled.RadioContainer>
@@ -302,7 +297,6 @@ export default function SizeForm(props: FormProps) {
             data={data}
             isTopClicked={isTopClicked}
             isAlertActive={isAlertActive}
-            isSaveButtonClicked={isSaveButtonClicked}
           />
           {children}
         </Styled.Form>

--- a/components/common/SizeForm/SizeInput.tsx
+++ b/components/common/SizeForm/SizeInput.tsx
@@ -29,15 +29,22 @@ interface InputProps {
   isTopClicked?: boolean;
   formType?: string | null;
   isAlertActive?: boolean;
-  isOpenToast?: boolean;
-  emptyClothesType?:string;
-  isSubmitActive?:boolean;
-
-
+  emptyClothesType?: string;
 }
 
 function SizeInput(props: InputProps) {
-  const { inputKey, measure, register, setValue, valid, data, isTopClicked, formType, isAlertActive, isOpenToast, emptyClothesType, isSubmitActive } = props;
+  const {
+    inputKey,
+    measure,
+    register,
+    setValue,
+    valid,
+    data,
+    isTopClicked,
+    formType,
+    isAlertActive,
+    emptyClothesType,
+  } = props;
   const label = measure ? `${inputKey} ${measure}` : `${inputKey}`;
 
   const [inputValue, setInputValue] = useState('');
@@ -47,10 +54,9 @@ function SizeInput(props: InputProps) {
     if (!data) return;
     if (!hasInputValueChanged) {
       //유저가 저장된 값을 변경한 적이 없을 때
-     
+
       setInputValue(parseFloat(`${data[inputKey]}`).toFixed(1));
       setValue(inputKey, parseFloat(`${data[inputKey]}`).toFixed(1));
-  
     } else {
       //유저가 저장된 값을 변경했을 때
       setInputValue(parseFloat(inputValue).toFixed(1));

--- a/components/common/SizeForm/SizeInput.tsx
+++ b/components/common/SizeForm/SizeInput.tsx
@@ -29,10 +29,15 @@ interface InputProps {
   isTopClicked?: boolean;
   formType?: string | null;
   isAlertActive?: boolean;
+  isOpenToast?: boolean;
+  emptyClothesType?:string;
+  isSubmitActive?:boolean;
+
+
 }
 
 function SizeInput(props: InputProps) {
-  const { inputKey, measure, register, setValue, valid, data, isTopClicked, formType, isAlertActive } = props;
+  const { inputKey, measure, register, setValue, valid, data, isTopClicked, formType, isAlertActive, isOpenToast, emptyClothesType, isSubmitActive } = props;
   const label = measure ? `${inputKey} ${measure}` : `${inputKey}`;
 
   const [inputValue, setInputValue] = useState('');
@@ -40,23 +45,22 @@ function SizeInput(props: InputProps) {
 
   useEffect(() => {
     if (!data) return;
-    if (data[inputKey] === null || data[inputKey] === 0) {
-      //저장된 값이 없을 때
-      setInputValue('');
-    } else if (!hasInputValueChanged) {
+    if (!hasInputValueChanged) {
       //유저가 저장된 값을 변경한 적이 없을 때
+     
       setInputValue(parseFloat(`${data[inputKey]}`).toFixed(1));
       setValue(inputKey, parseFloat(`${data[inputKey]}`).toFixed(1));
+  
     } else {
       //유저가 저장된 값을 변경했을 때
       setInputValue(parseFloat(inputValue).toFixed(1));
       setValue(inputKey, parseFloat(inputValue).toFixed(1));
     }
-  }, [data, inputKey, isAlertActive]);
+  }, [data, inputKey, isAlertActive, emptyClothesType]);
 
   useEffect(() => {
     setHasInputValueChanged(false);
-  }, [isTopClicked, measure, isAlertActive]);
+  }, [isTopClicked, measure, emptyClothesType]);
 
   useEffect(() => {
     if (!data) {

--- a/components/common/SizeForm/SizeInput.tsx
+++ b/components/common/SizeForm/SizeInput.tsx
@@ -29,17 +29,18 @@ interface InputProps {
   isTopClicked?: boolean;
   formType?: string | null;
   isAlertActive?: boolean;
+  isSaveButtonClicked?: boolean;
 }
 
 function SizeInput(props: InputProps) {
-  const { inputKey, measure, register, setValue, valid, data, isTopClicked, formType, isAlertActive } = props;
+  const { inputKey, measure, register, setValue, valid, data, isTopClicked, formType, isAlertActive, isSaveButtonClicked } = props;
   const label = measure ? `${inputKey} ${measure}` : `${inputKey}`;
 
   const [inputValue, setInputValue] = useState('');
   const [hasInputValueChanged, setHasInputValueChanged] = useState(false);
+
   useEffect(() => {
     if (!data) return;
-
     if (data[inputKey] === null || data[inputKey] === 0) {
       //저장된 값이 없을 때
       setInputValue('');
@@ -56,7 +57,7 @@ function SizeInput(props: InputProps) {
 
   useEffect(() => {
     setHasInputValueChanged(false);
-  }, [isTopClicked, measure]);
+  }, [isTopClicked, measure, isAlertActive]);
 
   useEffect(() => {
     if (!data) {

--- a/components/common/SizeForm/SizeInput.tsx
+++ b/components/common/SizeForm/SizeInput.tsx
@@ -29,11 +29,10 @@ interface InputProps {
   isTopClicked?: boolean;
   formType?: string | null;
   isAlertActive?: boolean;
-  isSaveButtonClicked?: boolean;
 }
 
 function SizeInput(props: InputProps) {
-  const { inputKey, measure, register, setValue, valid, data, isTopClicked, formType, isAlertActive, isSaveButtonClicked } = props;
+  const { inputKey, measure, register, setValue, valid, data, isTopClicked, formType, isAlertActive } = props;
   const label = measure ? `${inputKey} ${measure}` : `${inputKey}`;
 
   const [inputValue, setInputValue] = useState('');

--- a/components/mysize/Mysize.tsx
+++ b/components/mysize/Mysize.tsx
@@ -12,12 +12,12 @@ import useToast from 'components/common/Toast/useToast';
 
 type DataType =
   | {
-      총장: number | null;
+      총장: number;
       '어깨 너비': number;
       가슴: number;
     }
   | {
-      총장: number | null;
+      총장: number;
       밑위: number;
       허리: number;
       허벅지: number;
@@ -44,6 +44,7 @@ export default function Mysize() {
   const [isTopClicked, setIsTopClicked] = useState(true);
   const [clickedMeasure, setClickedMeasure] = useState('단면');
   const [emptyClothesType, setEmptyClothesType] = useState('없음');
+  const [isInitialValueWidth, setIsInitialValueWidth] = useState(true);
 
   //데이터 패칭
   const { allMysize } = useFetchMysize(isTopClicked, clickedMeasure, isAlertActive);
@@ -120,12 +121,16 @@ export default function Mysize() {
 
       if (isTopClicked && isWidthOfTop && clickedMeasure === '둘레') {
         setData({ 총장: topLength, '어깨 너비': shoulder, 가슴: chest * 2 });
+        setIsInitialValueWidth(true);
       } else if (isTopClicked && isWidthOfTop && clickedMeasure === '단면') {
         setData({ 총장: topLength, '어깨 너비': shoulder, 가슴: chest });
+        setIsInitialValueWidth(true);
       } else if (isTopClicked && isWidthOfTop === false && clickedMeasure === '단면') {
         setData({ 총장: topLength, '어깨 너비': shoulder, 가슴: chest / 2 });
+        setIsInitialValueWidth(false);
       } else if (isTopClicked && isWidthOfTop === false && clickedMeasure === '둘레') {
         setData({ 총장: topLength, '어깨 너비': shoulder, 가슴: chest });
+        setIsInitialValueWidth(false);
       } else if (isTopClicked === false && isWidthOfBottom && clickedMeasure === '둘레') {
         setData({
           총장: bottomLength,
@@ -134,8 +139,10 @@ export default function Mysize() {
           허벅지: thigh * 2,
           밑단: hem * 2,
         });
+        setIsInitialValueWidth(true);
       } else if (isTopClicked === false && isWidthOfBottom && clickedMeasure === '단면') {
         setData({ 총장: bottomLength, 밑위: rise, 허리: waist, 허벅지: thigh, 밑단: hem });
+        setIsInitialValueWidth(true);
       } else if (isTopClicked === false && isWidthOfBottom === false && clickedMeasure === '단면') {
         setData({
           총장: bottomLength,
@@ -144,12 +151,16 @@ export default function Mysize() {
           허벅지: thigh / 2,
           밑단: hem / 2,
         });
+        setIsInitialValueWidth(false);
       } else if (isTopClicked === false && isWidthOfBottom === false && clickedMeasure === '둘레') {
         setData({ 총장: bottomLength, 밑위: rise, 허리: waist, 허벅지: thigh, 밑단: hem });
+        setIsInitialValueWidth(false);
       } else if (isTopClicked === false && isWidthOfBottom === null) {
         setData({ 총장: bottomLength, 밑위: rise, 허리: waist, 허벅지: thigh, 밑단: hem });
+        setIsInitialValueWidth(true);
       } else if (isTopClicked && isWidthOfTop === null) {
         setData({ 총장: topLength, '어깨 너비': shoulder, 가슴: chest });
+        setIsInitialValueWidth(true);
       }
     }
     console.log(allMysize);
@@ -200,6 +211,7 @@ export default function Mysize() {
           isOpenToast={isOpenToast}
           emptyClothesType={emptyClothesType}
           isSubmitActive={isSubmitActive}
+          isInitialValueWidth={isInitialValueWidth}
         >
           <Styled.SaveButton onClick={handleClick} type="submit">
             저장

--- a/components/mysize/Mysize.tsx
+++ b/components/mysize/Mysize.tsx
@@ -44,7 +44,6 @@ export default function Mysize() {
   const [isTopClicked, setIsTopClicked] = useState(true);
   const [clickedMeasure, setClickedMeasure] = useState('단면');
   const [emptyClothesType, setEmptyClothesType] = useState('없음');
-  const [isSaveButtonClicked, setIsSaveButtonClicked] = useState(false);
 
   //데이터 패칭
   const { allMysize } = useFetchMysize(isTopClicked, clickedMeasure, isAlertActive);
@@ -198,7 +197,6 @@ export default function Mysize() {
           onClickMeasure={onClickMeasure}
           data={data}
           isTopClicked={isTopClicked}
-          isSaveButtonClicked={isSaveButtonClicked}
         >
           <Styled.SaveButton onClick={handleClick} type="submit">
             저장

--- a/components/mysize/Mysize.tsx
+++ b/components/mysize/Mysize.tsx
@@ -12,12 +12,12 @@ import useToast from 'components/common/Toast/useToast';
 
 type DataType =
   | {
-      총장: number;
+      총장: number | null;
       '어깨 너비': number;
       가슴: number;
     }
   | {
-      총장: number;
+      총장: number | null;
       밑위: number;
       허리: number;
       허벅지: number;
@@ -149,10 +149,11 @@ export default function Mysize() {
       } else if (isTopClicked === false && isWidthOfBottom === null) {
         setData({ 총장: bottomLength, 밑위: rise, 허리: waist, 허벅지: thigh, 밑단: hem });
       } else if (isTopClicked && isWidthOfTop === null) {
-        setData({ 총장: 0, 밑위: rise, 허리: waist, 허벅지: thigh, 밑단: hem });
+        setData({ 총장: topLength, '어깨 너비': shoulder, 가슴: chest });
       }
     }
-  }, [allMysize, isTopClicked, clickedMeasure, isAlertActive]);
+    console.log(allMysize);
+  }, [allMysize, isTopClicked, clickedMeasure, isAlertActive, emptyClothesType]);
 
 
   return (
@@ -196,6 +197,9 @@ export default function Mysize() {
           onClickMeasure={onClickMeasure}
           data={data}
           isTopClicked={isTopClicked}
+          isOpenToast={isOpenToast}
+          emptyClothesType={emptyClothesType}
+          isSubmitActive={isSubmitActive}
         >
           <Styled.SaveButton onClick={handleClick} type="submit">
             저장

--- a/components/mysize/Mysize.tsx
+++ b/components/mysize/Mysize.tsx
@@ -163,7 +163,6 @@ export default function Mysize() {
         setIsInitialValueWidth(true);
       }
     }
-    console.log(allMysize);
   }, [allMysize, isTopClicked, clickedMeasure, isAlertActive, emptyClothesType]);
 
 
@@ -208,9 +207,7 @@ export default function Mysize() {
           onClickMeasure={onClickMeasure}
           data={data}
           isTopClicked={isTopClicked}
-          isOpenToast={isOpenToast}
           emptyClothesType={emptyClothesType}
-          isSubmitActive={isSubmitActive}
           isInitialValueWidth={isInitialValueWidth}
         >
           <Styled.SaveButton onClick={handleClick} type="submit">

--- a/components/mysize/Mysize.tsx
+++ b/components/mysize/Mysize.tsx
@@ -150,9 +150,10 @@ export default function Mysize() {
       } else if (isTopClicked === false && isWidthOfBottom === null) {
         setData({ 총장: bottomLength, 밑위: rise, 허리: waist, 허벅지: thigh, 밑단: hem });
       } else if (isTopClicked && isWidthOfTop === null) {
-        setData({ 총장: bottomLength, 밑위: rise, 허리: waist, 허벅지: thigh, 밑단: hem });
+        setData({ 총장: 0, 밑위: rise, 허리: waist, 허벅지: thigh, 밑단: hem });
       }
     }
+    console.log(allMysize);
   }, [allMysize, isTopClicked, clickedMeasure, isAlertActive, emptyClothesType]);
 
 

--- a/components/mysize/Mysize.tsx
+++ b/components/mysize/Mysize.tsx
@@ -83,7 +83,7 @@ export default function Mysize() {
         });
       }
     }
-  }, [allMysize, emptyClothesType, isAlertActive]);
+  }, [allMysize, isAlertActive]);
 
   useEffect(() => {
     if (allMysize) {
@@ -152,8 +152,7 @@ export default function Mysize() {
         setData({ 총장: 0, 밑위: rise, 허리: waist, 허벅지: thigh, 밑단: hem });
       }
     }
-    console.log(allMysize);
-  }, [allMysize, isTopClicked, clickedMeasure, isAlertActive, emptyClothesType]);
+  }, [allMysize, isTopClicked, clickedMeasure, isAlertActive]);
 
 
   return (

--- a/components/mysize/Mysize.tsx
+++ b/components/mysize/Mysize.tsx
@@ -44,10 +44,10 @@ export default function Mysize() {
   const [isTopClicked, setIsTopClicked] = useState(true);
   const [clickedMeasure, setClickedMeasure] = useState('단면');
   const [emptyClothesType, setEmptyClothesType] = useState('없음');
+  const [isSaveButtonClicked, setIsSaveButtonClicked] = useState(false);
 
   //데이터 패칭
-  const { allMysize } = useFetchMysize(isTopClicked, clickedMeasure);
-
+  const { allMysize } = useFetchMysize(isTopClicked, clickedMeasure, isAlertActive);
   const onClickMeasure = (measure: string) => {
     setClickedMeasure(measure);
   };
@@ -84,10 +84,11 @@ export default function Mysize() {
         });
       }
     }
-  }, [allMysize, emptyClothesType]);
+  }, [allMysize, emptyClothesType, isAlertActive]);
 
   useEffect(() => {
     if (allMysize) {
+
       const { bottom } = allMysize;
       const { top } = allMysize;
 
@@ -112,9 +113,10 @@ export default function Mysize() {
         waist === null
       ) {
         setEmptyClothesType('하의');
-      }
-      if (topLength === null && shoulder === null && chest === null && isWidthOfTop === null) {
+      } else if (topLength === null && shoulder === null && chest === null && isWidthOfTop === null) {
         setEmptyClothesType('상의');
+      } else {
+        setEmptyClothesType('없음');
       }
 
       if (isTopClicked && isWidthOfTop && clickedMeasure === '둘레') {
@@ -151,7 +153,8 @@ export default function Mysize() {
         setData({ 총장: bottomLength, 밑위: rise, 허리: waist, 허벅지: thigh, 밑단: hem });
       }
     }
-  }, [allMysize, isTopClicked, clickedMeasure]);
+  }, [allMysize, isTopClicked, clickedMeasure, isAlertActive, emptyClothesType]);
+
 
   return (
     <Styled.Root>
@@ -194,6 +197,7 @@ export default function Mysize() {
           onClickMeasure={onClickMeasure}
           data={data}
           isTopClicked={isTopClicked}
+          isSaveButtonClicked={isSaveButtonClicked}
         >
           <Styled.SaveButton onClick={handleClick} type="submit">
             저장

--- a/hooks/queries/mySize.ts
+++ b/hooks/queries/mySize.ts
@@ -23,7 +23,7 @@ export const usePostMyTopSizeMutation = () => {
 
   return useMutation(postMyTopSize, {
     onSuccess() {
-      queryClient.invalidateQueries([QUERY_KEY.myTopSize]);
+      queryClient.invalidateQueries([QUERY_KEY.allMysize]);
     },
   });
 };
@@ -33,7 +33,7 @@ export const usePostMyBottomSizeMutation = () => {
 
   return useMutation(postMyBottomSize, {
     onSuccess() {
-      queryClient.invalidateQueries([QUERY_KEY.myBottomSize]);
+      queryClient.invalidateQueries([QUERY_KEY.allMysize]);
     },
   });
 };


### PR DESCRIPTION
## 이슈 넘버
- close #137
<!-- # 뒤에 이슈넘버를 써서 이슈를 닫아주세요 -->

## 구현 사항
<!-- 실제로 변경한 사항을 설명해주세요.-->
- [ ] ex. 랜딩페이지 헤더 구현
- [ ] 입력하지 않은 의류 유형 수정 시, 수정한 값이 빈칸으로 초기화되는 문제 해결
- [ ] 하의만 입력 시, 상의 쪽에 하의쪽 총장값이 들어있는 문제 해결
- [ ] 초기에 입력하지 않은 의류 유형에 잘못된 값을 넣고 저장 버튼 눌렀을 시, 기존 값이 모두 사라지던 문제 해결 
- [ ] 단면/둘레 초기 활성화 설정

## Need Review
- ~ 부분 이렇게 구현했어요, 피드백 부탁해요!
<!-- 어떤 부분에 리뷰어가 집중해야 하는지 or 해당 PR에서 논의가 필요한 사항을 적어주세요. -->
hooks/queries/mySize.ts
1. postMyTopSize 와 postMyBottomSize 를 수행하는 useMutation 에서 쿼리 키를 각각 topMysize, bottomMysize 에서 allMysize 로 바꾸어주었어요!! useFetchMysize 와 동일한 쿼리키를 가지게 함으로써 값이 업뎃되었을 때 자동으로 fetch 해 오도록 수정해 주었습니다!
   `   queryClient.invalidateQueries([QUERY_KEY.allMysize]);`

components/mysize/Mysize.tsx
1. setData 를 해주는 useEffect 의 의존성 배열에
 `[allMysize, isTopClicked, clickedMeasure, isAlertActive, emptyClothesType]);`
isAlertActive(저장 버튼을 클릭함에 따라 상태가 변함) state 를 넣어줌으로써 저장 버튼 클릭 시, 데이터가 즉각적으로 바뀌게 해 주었어요!

2.   useFetch 의 인자로, isAlertActive 를 주어 저장 버튼을 클릭할 때마다 새롭게 get 을 하게 했어요!
`const { allMysize } = useFetchMysize(isTopClicked, clickedMeasure, isAlertActive);`

3. 총장이 겹치는 이슈를 해결하기 위해, 상의값이 없는데 상의 탭이 클릭 된 경우, 총장에 0을 주어 값이 겹치지 않도록 해 주었어요!
`setData({ 총장: 0, 밑위: rise, 허리: waist, 허벅지: thigh, 밑단: hem });`

components/common/SizeForm/SizeInput.tsx
1. 저장 버튼을 누르면, inputValue 가 한 번도 바뀌지 않았다고 인식하게끔 isAlertActive 상태를 해당 useEffect 의 의존성 배열에 추가했어요!
```
useEffect(() => {
    setHasInputValueChanged(false);
  }, [isTopClicked, measure, isAlertActive]);

```

------------------------------------------------------------

1. components/common/SizeForm/SizeInput.tsx
```
if (data[inputKey] === null || data[inputKey] === 0) {
      //저장된 값이 없을 때
      setInputValue('');

```
이 부분을 제거해 주고, 
해당 useEffect 의 의존성 배열에 emptyClothesType 상태를 추가하고,
 [data, inputKey, isAlertActive, emptyClothesType]);

사용자가 인풋값을 새롭게 저장하지 않았으니, 기존의 데이터를 가져오라는 useEffect 의 의존성 배열에도 emptyClothesType 상태를 추가해 줌으로써 구현했습니다!
useEffect(() => {
    setHasInputValueChanged(false);
 }, [isTopClicked, measure, emptyClothesType]);
여기서 기존에 사용했던 isAlertActive 를 지운 까닭은, 그렇게 했더니, 사용자가 잘못된 값을 적어서 경고창만 뜨고 저장이 되지 않을 경우, hasInputValueChanged 값이 false 로 되어서 기존에 저장된 데이터를 패칭해 오므로, 기존에 값이 아예 없었던, 입력하지 않은 의류 유형의 경우 값이 초기화되는 것처럼 보여서 그런 것이었어요..! 그래서 오로지 정상적으로 저장되었을 때만 해당 useEffect 를 실행시키고 싶었고, 이를 위해 emptyClothesType 을 도입했습니다! 이는 정상 저장이 될 경우, 값이 '없음' 으로 변화하니까, "저장" 이라는 상태를 정확히 표현할 수 있을 것이라 생각했어요!!

2. components/common/SizeForm/SizeForm.tsx
기능 명세를 자세히 보니까, 오디오 버튼의 초기 상태를 설정해 주어야 해서 설정해 주었습니다!
초기 활성화값이 단면인지, 둘레여야 하는지를 알려주기 위해 MySize 에서 isInitialValueWidth 라는 상태를 만들어 SizeForm 에 전달해 주엇어요!
```
useEffect(() => {
    if (isInitialValueWidth) {
      setMeasure('단면');
      sendMeasureValue('단면');
    } else if(isInitialValueWidth === false){
      setMeasure('둘레');
      sendMeasureValue('둘레');
    } 
    else {
      setMeasure('단면');
      sendMeasureValue('단면');
    }
  }, [isTopClicked, formType, isInitialValueWidth]);
```
그 후 위와 같은 useEffect 를 이용해 사용자가 설정한 초기값이 단면일 경우 단면을, 둘레일 경우 둘레를 초기에 활성화할 수 있게 하였고, 입력하지 않은 의류 유형에 대해서는 항상 단면이 활성화될 수 있게 처리했습니다!(아래 사진은 제가 참고한 기능 명세서!!)
![image](https://user-images.githubusercontent.com/86764406/221870131-b34a1500-7184-4cab-81ba-a3b76af50730.png)


## 📸 스크린샷
<!-- 팀원들이 이해하기 쉽도록 스크린샷을 첨부해주세요. -->

https://user-images.githubusercontent.com/86764406/221691129-2e2d89af-d52b-44d6-b517-1bf487b42dc8.mov


https://user-images.githubusercontent.com/86764406/221864702-446b28b9-9825-4f7b-9349-1ab860d0471d.mov



https://user-images.githubusercontent.com/86764406/221872836-0d9493ce-92ee-400d-b212-5b24f2a42d6a.mov


## Reference
<!-- 참고한 사이트가 있다면 링크를 공유해주세요. -->
