### PR TITLE
fix/#145: login 페이지에서 useRedirect 호출 제거

### DIFF
--- a/apis/index.tsx
+++ b/apis/index.tsx
@@ -1,7 +1,5 @@
-/* eslint-disable @typescript-eslint/no-empty-function */
 import { PropsWithChildren, useEffect } from 'react';
 import axios, { AxiosRequestConfig } from 'axios';
-import Cookies from 'js-cookie';
 import { useRouter } from 'next/router';
 import { useRecoilValue } from 'recoil';
 import { tokenState } from 'states/user';

--- a/pages/login/index.tsx
+++ b/pages/login/index.tsx
@@ -10,11 +10,9 @@ import theme from 'styles/theme';
 import { lottieMapper } from '@/components/common/modal/LottieModal';
 import LottiePlayer from '@/components/common/modal/LottiePlayer';
 import { useAuth } from '@/hooks/business/user';
-import useRedirect from '@/hooks/business/useRedirect';
 import Layout from 'components/common/Layout';
 
 function Login() {
-  const { isLoading } = useRedirect();
   const { authLogin } = useAuth();
   const router = useRouter();
   const login = useGoogleLogin({


### PR DESCRIPTION
## 이슈 넘버
- close #145
<!-- # 뒤에 이슈넘버를 써서 이슈를 닫아주세요 -->

## 구현 사항
<!-- 실제로 변경한 사항을 설명해주세요.-->
- [x] login 페이지에서 useRedirect 호출을 제거했습니다. useRedirect 내에서 mypage api를 호출하고 있어서 /login에 도착하면  interceptor에 의해 무조건 alert가 뜨는 구조였기 때문에 삭제했어요.


## Need Review
- ~ 부분 이렇게 구현했어요, 피드백 부탁해요!
<!-- 어떤 부분에 리뷰어가 집중해야 하는지 or 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

## 📸 스크린샷
<!-- 팀원들이 이해하기 쉽도록 스크린샷을 첨부해주세요. -->

## Reference
<!-- 참고한 사이트가 있다면 링크를 공유해주세요. -->
