### PR TITLE
fix: 리다이렉트 수정 및 테스트 완료

### DIFF
--- a/components/common/SizeForm/Alert.tsx
+++ b/components/common/SizeForm/Alert.tsx
@@ -11,7 +11,6 @@ function Alert(props: AlertProps) {
   const { message, setIsActive } = props;
 
   const disableClick = () => {
-    //(document.activeElement as HTMLElement).blur();
     document.getElementById('__next')?.classList.add('non-clickable');
   };
   const enableClick = () => {
@@ -25,8 +24,6 @@ function Alert(props: AlertProps) {
   return (
     <Styled.Root>
       {message}
-      <br />
-      다시 입력해 주세요.
       <Styled.Button onClick={() => setIsActive(false)}>확인</Styled.Button>
     </Styled.Root>
   );
@@ -52,6 +49,7 @@ const Styled = {
     border-radius: 0.5rem;
     color: ${theme.colors.black};
     ${theme.fonts.caption};
+    white-space: pre-wrap;
     z-index: 10;
   `,
   Button: styled.button`

--- a/components/common/SizeForm/SizeForm.tsx
+++ b/components/common/SizeForm/SizeForm.tsx
@@ -1,5 +1,7 @@
-import React, { ReactNode, use, useEffect, useState } from 'react';
+import React, { ReactNode, useEffect, useState } from 'react';
 import { FieldValues, SubmitHandler, useForm } from 'react-hook-form';
+import { useRecoilState } from 'recoil';
+import { isAlreadyUserState } from 'states/user';
 import styled from 'styled-components';
 import theme from 'styles/theme';
 import { BottomSizeInput, TopSizeInput } from 'types/mySize/client';
@@ -206,7 +208,7 @@ export default function SizeForm(props: FormProps) {
     } else {
       setSkip && setSkip(false);
     }
-  }, [progress]);
+  }, [progress, isOption]);
 
   const sendMeasureValue = (measure: string) => {
     onClickMeasure && onClickMeasure(measure);
@@ -217,11 +219,10 @@ export default function SizeForm(props: FormProps) {
     if (isInitialValueWidth) {
       setMeasure('단면');
       sendMeasureValue('단면');
-    } else if(isInitialValueWidth === false){
+    } else if (isInitialValueWidth === false) {
       setMeasure('둘레');
       sendMeasureValue('둘레');
-    } 
-    else {
+    } else {
       setMeasure('단면');
       sendMeasureValue('단면');
     }

--- a/components/common/SizeForm/SizeInput.tsx
+++ b/components/common/SizeForm/SizeInput.tsx
@@ -83,10 +83,10 @@ function SizeInput(props: InputProps) {
           step="0.1"
           value={inputValue}
           {...register(inputKey, {
-            required: true,
+            required: `아직 모든 사이즈 값을 입력하지 않은 것 같아요!\n사이즈를 다시 한 번 입력해주세요.`,
             validate: (value) =>
               value < valid.min || value > valid.max
-                ? `${label}은(는) 최소 ${valid.min}부터 최대 ${valid.max}까지 입력할 수 있습니다.`
+                ? `${label}은(는) 최소 ${valid.min}부터 최대 ${valid.max}까지 입력할 수 있습니다.\n다시 입력해주세요.`
                 : true,
           })}
           onBlur={(e) => e.currentTarget.value && setValue(inputKey, parseFloat(e.currentTarget.value).toFixed(1))}

--- a/components/mypage/MypageMain.tsx
+++ b/components/mypage/MypageMain.tsx
@@ -1,10 +1,10 @@
-import { lazy, Suspense,useState } from 'react';
+import { lazy, Suspense, useState } from 'react';
 import profileDefault from 'assets/icon/profileDefault.svg';
 import sizeReplacement from 'assets/icon/sizeReplacement.png';
 import Image from 'next/image';
 import { useRouter } from 'next/router';
-import { useResetRecoilState } from 'recoil';
-import { tokenState } from 'states/user';
+import { useRecoilState, useResetRecoilState } from 'recoil';
+import { isAlreadyUserState, tokenState } from 'states/user';
 import styled from 'styled-components';
 import theme from 'styles/theme';
 
@@ -20,11 +20,13 @@ function MyPageMain() {
   const [isHistoryModalOpen, setIsHistoryModalOpen] = useState(false);
   const [isLeaveModalOpen, setIsLeaveModalOpen] = useState(false);
   const [isButtonActivated, setIsButtonActivated] = useState(true);
+  const [, setUserState] = useRecoilState(isAlreadyUserState);
 
   const onClickHistoryModal = () => {
     setIsHistoryModalOpen(!isHistoryModalOpen);
   };
   const onClickLeaveModal = () => {
+    setUserState('pending');
     setIsLeaveModalOpen(!isLeaveModalOpen);
   };
   const onClickCancel = () => {

--- a/components/register/Register.tsx
+++ b/components/register/Register.tsx
@@ -3,7 +3,7 @@ import { LoginMouseImg, SizeGuideImg } from 'assets/img';
 import Image from 'next/image';
 import { useRouter } from 'next/router';
 import { useRecoilState } from 'recoil';
-import { isRegisterState } from 'states/user';
+import { isAlreadyUserState } from 'states/user';
 import styled from 'styled-components';
 import theme from 'styles/theme';
 
@@ -22,7 +22,7 @@ function RegisterLanding() {
   const [isAlertActive, setIsAlertActive] = useState<boolean>(false);
   const [isTip, setIsTip] = useState<boolean>(false);
   const [skip, setSkip] = useState<boolean>(false);
-  const [, setIsRegister] = useRecoilState(isRegisterState);
+  const [, setUserState] = useRecoilState(isAlreadyUserState);
   const router = useRouter();
 
   useEffect(() => {
@@ -40,6 +40,8 @@ function RegisterLanding() {
   const onClickSize = () => {
     if (progress === 3) {
       // 서버에 데이터 넘기고 home으로 이동
+      setUserState('done');
+      router.push('/home');
     } else if (isNextActive) {
       setProgress((prev) => prev + 1);
       setIsNextActive(false);
@@ -48,8 +50,7 @@ function RegisterLanding() {
 
   const onClickNextButton = () => {
     if (skip) {
-      localStorage.setItem('isRegister', 'true');
-      setIsRegister(true);
+      setUserState('done');
       router.push('/home');
     } else {
       setIsAlertActive(true);
@@ -61,8 +62,6 @@ function RegisterLanding() {
       setProgress(progress + 1);
       setIsNextActive(false);
     } else {
-      localStorage.setItem('isRegister', 'true');
-      setIsRegister(true);
       router.push('/home');
     }
   };
@@ -121,7 +120,7 @@ function RegisterLanding() {
             formType={selectedOption === '하의' ? '하의' : '상의'}
             setIsSubmitActive={setIsNextActive}
             onSuccessSubmit={onSuccessSubmit}
-            isOption={selectedOption === '상/하의' ? false : true}
+            isOption={false}
           >
             <NextButton isActive={isNextActive} onClick={onClickNextButton} />
           </SizeForm>

--- a/hooks/business/useRedirect.ts
+++ b/hooks/business/useRedirect.ts
@@ -1,23 +1,28 @@
 import React, { useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
-
-import { useFetchUserInformation } from '../queries/mypageHistory';
+import { useRecoilValue } from 'recoil';
+import { isAlreadyUserState } from 'states/user';
 
 function useRedirect() {
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const router = useRouter();
-  const { userInformation } = useFetchUserInformation();
-  const userState = userInformation?.isAlreadyUser;
+  const userState = useRecoilValue(isAlreadyUserState);
 
   const onRedirect = () => {
-    if (userState === 'pending') {
+    const token = localStorage.getItem('token');
+
+    if (userState === 'pending' && token) {
       router.replace('/register');
-    } else if (userState === 'done') {
+    } else if (userState === 'done' && token) {
       router.replace('/home');
+    } else {
+      router.replace('/login');
     }
+    setIsLoading(false);
   };
 
   useEffect(() => {
+    setIsLoading(true);
     userState && onRedirect();
   }, []);
 

--- a/hooks/business/user.ts
+++ b/hooks/business/user.ts
@@ -1,5 +1,5 @@
-import { useRecoilState } from 'recoil';
-import { tokenState, userIdState } from 'states/user';
+import { useRecoilState, useRecoilValue } from 'recoil';
+import { isAlreadyUserState, tokenState, userIdState } from 'states/user';
 import { AuthInput } from 'types/user/client';
 
 import { useAuthMutation } from '../queries/user';
@@ -8,6 +8,7 @@ export const useAuth = () => {
   const authMutate = useAuthMutation();
   const [, setToken] = useRecoilState(tokenState);
   const [, setUserId] = useRecoilState(userIdState);
+  const userState = useRecoilValue(isAlreadyUserState);
 
   const authLogin = (body: AuthInput, onSuccessLogin: (isAlreadyUser: 'pending' | 'done') => void) => {
     authMutate.mutate(body, {
@@ -18,7 +19,7 @@ export const useAuth = () => {
         setUserId(userId);
 
         // 초기 사이즈 설정 페이지로 이동하기
-        onSuccessLogin(isAlreadyUser);
+        onSuccessLogin(userState);
       },
     });
   };

--- a/pages/login/index.tsx
+++ b/pages/login/index.tsx
@@ -4,16 +4,20 @@ import { GoogleLoginImg, OwnSizeLogoImg } from 'assets/img';
 import axios from 'axios';
 import Image from 'next/image';
 import { useRouter } from 'next/router';
+import { useRecoilState } from 'recoil';
+import { isAlreadyUserState } from 'states/user';
 import styled from 'styled-components';
 import theme from 'styles/theme';
 
 import { lottieMapper } from '@/components/common/modal/LottieModal';
 import LottiePlayer from '@/components/common/modal/LottiePlayer';
 import { useAuth } from '@/hooks/business/user';
+import useRedirect from '@/hooks/business/useRedirect';
 import Layout from 'components/common/Layout';
 
 function Login() {
   const { authLogin } = useAuth();
+  const { isLoading } = useRedirect();
   const router = useRouter();
   const login = useGoogleLogin({
     onSuccess: async (tokenResponse) => {
@@ -39,7 +43,9 @@ function Login() {
     }
   };
 
-  return (
+  return isLoading ? (
+    <></>
+  ) : (
     <Layout noHeader noMenuBar noFooter>
       <Styled.Root>
         <Styled.Header>

--- a/states/user.ts
+++ b/states/user.ts
@@ -15,8 +15,8 @@ export const userIdState = atom({
   effects_UNSTABLE: [persistAtom],
 });
 
-export const isRegisterState = atom({
-  key: 'isRegister',
-  default: null,
+export const isAlreadyUserState = atom<'pending' | 'done'>({
+  key: 'isAlreadyUserState',
+  default: 'pending',
   effects_UNSTABLE: [persistAtom],
 });


### PR DESCRIPTION
## 이슈 넘버
- close #156 
<!-- # 뒤에 이슈넘버를 써서 이슈를 닫아주세요 -->

## 구현 사항
<!-- 실제로 변경한 사항을 설명해주세요.-->
- [ ] 서버에서 isAlreadyUser 값을 관리하는 기존 방식에서 recoil persist 사용 방식으로 변경


## Need Review
- pending/done 두가지 값만 갖는 isAlreadyUserState를 사용
- isAlreadyUserState와 localStorage의 token을 모두 검사해 리다이렉트
- 탈퇴시 pending 처리
- 지금은 로그인한 상태에서 루트 경로로 들어가면 /login으로 리다이렉트된 후 /home으로 보내주는데, /home으로 리다이렉트 되게끔 nextconfig를 수정하는 방법도 고려해보면 좋을 것 같습니다.

## 📸 스크린샷
<!-- 팀원들이 이해하기 쉽도록 스크린샷을 첨부해주세요. -->

## Reference
<!-- 참고한 사이트가 있다면 링크를 공유해주세요. -->
