### PR TITLE
fix/#159: 리다이렉트 시 /register로 이동되는 이슈 해결

### DIFF
--- a/apis/index.tsx
+++ b/apis/index.tsx
@@ -2,7 +2,7 @@ import { PropsWithChildren, useEffect } from 'react';
 import axios, { AxiosRequestConfig } from 'axios';
 import { useRouter } from 'next/router';
 import { useRecoilValue } from 'recoil';
-import { tokenState } from 'states/user';
+import { userState } from 'states/user';
 
 import { useRefresh } from '@/hooks/queries/auth';
 
@@ -29,7 +29,7 @@ export default function createAxios(endpoint: string, config?: AxiosRequestConfi
 
 function AxiosInterceptor({ children }: PropsWithChildren) {
   const router = useRouter();
-  const accessToken = useRecoilValue(tokenState);
+  const { token: accessToken } = useRecoilValue(userState);
   const refresh = useRefresh({ accessToken });
 
   const requestIntercept = client.interceptors.request.use(

--- a/components/common/SizeForm/SizeForm.tsx
+++ b/components/common/SizeForm/SizeForm.tsx
@@ -1,7 +1,5 @@
 import React, { ReactNode, useEffect, useState } from 'react';
 import { FieldValues, SubmitHandler, useForm } from 'react-hook-form';
-import { useRecoilState } from 'recoil';
-import { isAlreadyUserState } from 'states/user';
 import styled from 'styled-components';
 import theme from 'styles/theme';
 import { BottomSizeInput, TopSizeInput } from 'types/mySize/client';
@@ -35,6 +33,7 @@ interface FormProps {
   isTopClicked?: boolean;
   emptyClothesType?: string;
   isInitialValueWidth?: boolean;
+  selectedOption?: OptionType;
 }
 
 // 상의 총장, 어깨너비
@@ -103,6 +102,7 @@ export default function SizeForm(props: FormProps) {
     isTopClicked,
     emptyClothesType,
     isInitialValueWidth,
+    selectedOption,
   } = props;
   const [measure, setMeasure] = useState<'단면' | '둘레'>('단면');
 
@@ -140,10 +140,11 @@ export default function SizeForm(props: FormProps) {
         inputData.isWidthOfTop = false;
       }
 
-      if (isOption && progress === 2) {
+      if (selectedOption !== '상/하의' && progress === 2) {
         inputData.isAlreadyUser = 'done';
       }
-      if (!isOption && progress === 3) {
+
+      if (progress === 3) {
         inputData.isAlreadyUser = 'done';
       }
 
@@ -170,10 +171,10 @@ export default function SizeForm(props: FormProps) {
         inputData.isWidthOfBottom = false;
       }
 
-      if (isOption && progress === 2) {
+      if (selectedOption !== '상/하의' && progress === 2) {
         inputData.isAlreadyUser = 'done';
       }
-      if (!isOption && progress === 3) {
+      if (progress === 3) {
         inputData.isAlreadyUser = 'done';
       }
 

--- a/components/mypage/MypageMain.tsx
+++ b/components/mypage/MypageMain.tsx
@@ -4,7 +4,7 @@ import sizeReplacement from 'assets/icon/sizeReplacement.png';
 import Image from 'next/image';
 import { useRouter } from 'next/router';
 import { useRecoilState, useResetRecoilState } from 'recoil';
-import { isAlreadyUserState, tokenState } from 'states/user';
+import { userState } from 'states/user';
 import styled from 'styled-components';
 import theme from 'styles/theme';
 
@@ -20,13 +20,21 @@ function MyPageMain() {
   const [isHistoryModalOpen, setIsHistoryModalOpen] = useState(false);
   const [isLeaveModalOpen, setIsLeaveModalOpen] = useState(false);
   const [isButtonActivated, setIsButtonActivated] = useState(true);
-  const [, setUserState] = useRecoilState(isAlreadyUserState);
+  const [user, setUser] = useRecoilState(userState);
+  const resetUserState = useResetRecoilState(userState);
+
+  const resetToken = () => {
+    setUser({
+      ...user,
+      token: '',
+    });
+  };
 
   const onClickHistoryModal = () => {
     setIsHistoryModalOpen(!isHistoryModalOpen);
   };
   const onClickLeaveModal = () => {
-    setUserState('pending');
+    resetUserState();
     setIsLeaveModalOpen(!isLeaveModalOpen);
   };
   const onClickCancel = () => {
@@ -52,7 +60,6 @@ function MyPageMain() {
   };
 
   const router = useRouter();
-  const resetToken = useResetRecoilState(tokenState);
   const { userInformation } = useFetchUserInformation();
   const { history } = useFetchMyPageHistory();
 

--- a/components/register/Register.tsx
+++ b/components/register/Register.tsx
@@ -2,8 +2,6 @@ import React, { useEffect, useState } from 'react';
 import { LoginMouseImg, SizeGuideImg } from 'assets/img';
 import Image from 'next/image';
 import { useRouter } from 'next/router';
-import { useRecoilState } from 'recoil';
-import { isAlreadyUserState } from 'states/user';
 import styled from 'styled-components';
 import theme from 'styles/theme';
 
@@ -22,7 +20,6 @@ function RegisterLanding() {
   const [isAlertActive, setIsAlertActive] = useState<boolean>(false);
   const [isTip, setIsTip] = useState<boolean>(false);
   const [skip, setSkip] = useState<boolean>(false);
-  const [, setUserState] = useRecoilState(isAlreadyUserState);
   const router = useRouter();
 
   useEffect(() => {
@@ -40,7 +37,7 @@ function RegisterLanding() {
   const onClickSize = () => {
     if (progress === 3) {
       // 서버에 데이터 넘기고 home으로 이동
-      setUserState('done');
+      // setUserState('done');
       router.push('/home');
     } else if (isNextActive) {
       setProgress((prev) => prev + 1);
@@ -50,7 +47,7 @@ function RegisterLanding() {
 
   const onClickNextButton = () => {
     if (skip) {
-      setUserState('done');
+      // setUserState('done');
       router.push('/home');
     } else {
       setIsAlertActive(true);
@@ -121,6 +118,7 @@ function RegisterLanding() {
             setIsSubmitActive={setIsNextActive}
             onSuccessSubmit={onSuccessSubmit}
             isOption={false}
+            selectedOption={selectedOption}
           >
             <NextButton isActive={isNextActive} onClick={onClickNextButton} />
           </SizeForm>
@@ -135,6 +133,7 @@ function RegisterLanding() {
             isOption={selectedOption === '상/하의' ? false : true}
             skip={skip}
             setSkip={setSkip}
+            selectedOption={selectedOption}
           >
             <NextButton isActive={isNextActive} onClick={onClickNextButton} />
           </SizeForm>

--- a/hooks/business/useRedirect.ts
+++ b/hooks/business/useRedirect.ts
@@ -1,29 +1,15 @@
-import React, { useEffect, useState } from 'react';
-import { useRouter } from 'next/router';
-import { useRecoilValue } from 'recoil';
-import { isAlreadyUserState } from 'states/user';
+import { useEffect, useState } from 'react';
 
 function useRedirect() {
   const [isLoading, setIsLoading] = useState<boolean>(false);
-  const router = useRouter();
-  const userState = useRecoilValue(isAlreadyUserState);
 
   const onRedirect = () => {
-    const token = localStorage.getItem('token');
-
-    if (userState === 'pending' && token) {
-      router.replace('/register');
-    } else if (userState === 'done' && token) {
-      router.replace('/home');
-    } else {
-      router.replace('/login');
-    }
     setIsLoading(false);
   };
 
   useEffect(() => {
     setIsLoading(true);
-    userState && onRedirect();
+    onRedirect();
   }, []);
 
   return { isLoading };

--- a/hooks/business/user.ts
+++ b/hooks/business/user.ts
@@ -1,25 +1,31 @@
-import { useRecoilState, useRecoilValue } from 'recoil';
-import { isAlreadyUserState, tokenState, userIdState } from 'states/user';
+import { useRouter } from 'next/router';
+import { useRecoilState } from 'recoil';
+import { userState } from 'states/user';
 import { AuthInput } from 'types/user/client';
 
 import { useAuthMutation } from '../queries/user';
 
 export const useAuth = () => {
+  const router = useRouter();
   const authMutate = useAuthMutation();
-  const [, setToken] = useRecoilState(tokenState);
-  const [, setUserId] = useRecoilState(userIdState);
-  const userState = useRecoilValue(isAlreadyUserState);
+  const [user, setUser] = useRecoilState(userState);
 
-  const authLogin = (body: AuthInput, onSuccessLogin: (isAlreadyUser: 'pending' | 'done') => void) => {
+  const authLogin = (body: AuthInput) => {
     authMutate.mutate(body, {
       onSuccess({ userId, token, isAlreadyUser }) {
+        if (isAlreadyUser === 'pending') {
+          router.push('/register');
+        } else {
+          router.push('/home');
+        }
+
         localStorage.setItem('userId', `${userId}`);
         localStorage.setItem('token', `${token}`);
-        setToken(token);
-        setUserId(userId);
-
-        // 초기 사이즈 설정 페이지로 이동하기
-        onSuccessLogin(userState);
+        setUser({
+          ...user,
+          token,
+          userId,
+        });
       },
     });
   };

--- a/hooks/queries/auth.ts
+++ b/hooks/queries/auth.ts
@@ -2,7 +2,7 @@ import { useQueryClient } from 'react-query';
 import { AxiosError } from 'axios';
 import { useRouter } from 'next/router';
 import { useResetRecoilState } from 'recoil';
-import { tokenState } from 'states/user';
+import { userState } from 'states/user';
 import { RefreshInput } from 'types/auth/client';
 
 import { fetchRefresh } from '@/apis/auth';
@@ -12,7 +12,11 @@ export const useRefresh = (token: RefreshInput) => {
   const router = useRouter();
   const queryClient = useQueryClient();
   const { reportError } = useErrorBubbling();
-  const resetToken = useResetRecoilState(tokenState);
+  const resetUserState = useResetRecoilState(userState);
+
+  const resetToken = () => {
+    resetUserState();
+  };
 
   const refresh = async () => {
     try {

--- a/pages/home/index.tsx
+++ b/pages/home/index.tsx
@@ -1,9 +1,7 @@
-import useRedirect from '@/hooks/business/useRedirect';
 import Layout from 'components/common/Layout';
 import HomeLanding from 'components/home/HomeLanding';
 
 function Home() {
-  const { isLoading } = useRedirect();
   return (
     <Layout>
       <HomeLanding />

--- a/pages/login/index.tsx
+++ b/pages/login/index.tsx
@@ -3,9 +3,8 @@ import { useGoogleLogin } from '@react-oauth/google';
 import { GoogleLoginImg, OwnSizeLogoImg } from 'assets/img';
 import axios from 'axios';
 import Image from 'next/image';
-import { useRouter } from 'next/router';
 import { useRecoilState } from 'recoil';
-import { isAlreadyUserState } from 'states/user';
+import { userState } from 'states/user';
 import styled from 'styled-components';
 import theme from 'styles/theme';
 
@@ -18,20 +17,14 @@ import Layout from 'components/common/Layout';
 function Login() {
   const { authLogin } = useAuth();
   const { isLoading } = useRedirect();
-  const router = useRouter();
+
   const login = useGoogleLogin({
     onSuccess: async (tokenResponse) => {
       const { data } = await axios.get('https://www.googleapis.com/oauth2/v3/userinfo', {
         headers: { Authorization: `Bearer ${tokenResponse.access_token}` },
       });
 
-      authLogin(data, (isAlreadyUser: 'pending' | 'done') => {
-        if (isAlreadyUser === 'done') {
-          router.push('/home');
-        } else {
-          router.push('/register');
-        }
-      });
+      authLogin(data);
     },
   });
   const [page, setPage] = useState(0);

--- a/states/user.ts
+++ b/states/user.ts
@@ -3,20 +3,16 @@ import { recoilPersist } from 'recoil-persist';
 
 const { persistAtom } = recoilPersist();
 
-export const tokenState = atom({
-  key: 'token',
-  default: '',
-  effects_UNSTABLE: [persistAtom],
-});
+interface UserStateType {
+  token: string;
+  userId: number;
+}
 
-export const userIdState = atom({
-  key: 'userId',
-  default: 0,
-  effects_UNSTABLE: [persistAtom],
-});
-
-export const isAlreadyUserState = atom<'pending' | 'done'>({
-  key: 'isAlreadyUserState',
-  default: 'pending',
+export const userState = atom<UserStateType>({
+  key: 'user',
+  default: {
+    token: '',
+    userId: 0,
+  },
   effects_UNSTABLE: [persistAtom],
 });


### PR DESCRIPTION
## 이슈 넘버
- close #159 
- <!-- # 뒤에 이슈넘버를 써서 이슈를 닫아주세요 -->

## 구현 사항
<!-- 실제로 변경한 사항을 설명해주세요.-->
- [x] token, userId state 하나로 묶어서 사용
```tsx
export const userState = atom<UserStateType>({
  key: 'user',
  default: {
    token: '',
    userId: 0,
  },
  effects_UNSTABLE: [persistAtom],
});
```
- [x] 클라이언트에서 state로 관리하는 isAlreadyUser는 삭제하고 서버에서 response body로 넘겨주는 isAlreadyUser를 사용
- [x] `SizeForm` 컴포넌트에 `selectedOption` props 추가 👉 선택한 옵션이 상/하의인지 아닌지 구분하기 위함

## Need Review
- ~ 부분 이렇게 구현했어요, 피드백 부탁해요!
<!-- 어떤 부분에 리뷰어가 집중해야 하는지 or 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

## 📸 스크린샷
<!-- 팀원들이 이해하기 쉽도록 스크린샷을 첨부해주세요. -->

## Reference
<!-- 참고한 사이트가 있다면 링크를 공유해주세요. -->
